### PR TITLE
Niteが行動を切り替えられるようにした

### DIFF
--- a/src/main/kotlin/jp/trap/conqest/commands/CommandConQest.kt
+++ b/src/main/kotlin/jp/trap/conqest/commands/CommandConQest.kt
@@ -9,9 +9,6 @@ import jp.trap.conqest.game.nite.NormalNite
 import net.kyori.adventure.text.Component
 import org.bukkit.entity.*
 
-// TODO 仮 本体はNiteManager的なところに保持するべき
-var nite: NormalNite? = null
-
 class CommandConQest(val plugin: Main) : Commands.Command {
     override fun literalCommandNode(): LiteralCommandNode<CommandSourceStack> {
         return io.papermc.paper.command.brigadier.Commands
@@ -33,8 +30,7 @@ class CommandConQest(val plugin: Main) : Commands.Command {
                             if ((ctx.source.sender is Player).not()) return@executes 0
                             val player = ctx.source.sender as Player
                             val arg = ctx.getArgument("name", String::class.java)
-                            // TODO: 仮 本来はNiteManager的なところに保持するべき
-                            nite = NormalNite(player.location, arg, plugin)
+                            plugin.gameManager.addNite(NormalNite(player.location, arg, player, plugin), player)
                             0
                         }
                 )

--- a/src/main/kotlin/jp/trap/conqest/game/GameManager.kt
+++ b/src/main/kotlin/jp/trap/conqest/game/GameManager.kt
@@ -3,11 +3,13 @@ package jp.trap.conqest.game
 import org.bukkit.command.CommandSender
 import org.bukkit.entity.Player
 import org.bukkit.plugin.Plugin
+import java.util.*
 
 class GameManager(val plugin: Plugin) {
 
     private var state: GameState = GameState.BeforeGame(this)
     private val players: MutableList<Player> = mutableListOf()
+    private val nites: MutableMap<UUID, MutableList<Nite<*>>> = mutableMapOf()
 
     fun setState(state: GameState) {
         this.state = state
@@ -25,6 +27,14 @@ class GameManager(val plugin: Plugin) {
 
     fun executeCommand(command: GameCommand, sender: CommandSender): Int {
         return state.executeCommand(command, sender)
+    }
+
+    fun getNites(player: Player): List<Nite<*>> {
+        return nites.computeIfAbsent(player.uniqueId) { ArrayList() }
+    }
+
+    fun addNite(nite: Nite<*>, master: Player) {
+        nites.computeIfAbsent(master.uniqueId) { ArrayList() }.add(nite)
     }
 
 }

--- a/src/main/kotlin/jp/trap/conqest/game/Nite.kt
+++ b/src/main/kotlin/jp/trap/conqest/game/Nite.kt
@@ -3,40 +3,57 @@ package jp.trap.conqest.game
 import net.kyori.adventure.text.Component
 import org.bukkit.Location
 import org.bukkit.attribute.Attribute
-import org.bukkit.entity.Entity
-import org.bukkit.entity.EntityType
-import org.bukkit.entity.LivingEntity
-import org.bukkit.entity.Mob
+import org.bukkit.entity.*
 import org.bukkit.plugin.Plugin
+import org.bukkit.potion.PotionEffect
+import org.bukkit.potion.PotionEffectType
 
-abstract class Nite<T>(location: Location, type: EntityType, name: String, plugin: Plugin)
+abstract class Nite<T>(location: Location, type: EntityType, name: String, val master: Player, val plugin: Plugin)
         where T : Entity, T : Mob {
     private var entity: T = location.world.spawnEntity(
         location, type, false
     ) as T
-    private var target: LivingEntity? = null
-    private var attack: Boolean = true
     private val speed = 0.5
     private val damage = 1.0
+    private val handLength = 3.0
+    var state: NiteState = NiteState.FollowMaster(plugin, this)
+    abstract val name: String
 
     init {
         entity.customName(Component.text(name))
+        entity.addPotionEffect(PotionEffect(PotionEffectType.GLOWING, Int.MAX_VALUE, 1))
         if (entity.getAttribute(Attribute.ATTACK_DAMAGE) == null) {
             entity.registerAttribute(Attribute.ATTACK_DAMAGE)
             entity.getAttribute(Attribute.ATTACK_DAMAGE)?.baseValue = damage
         }
-        plugin.server.scheduler.runTaskTimer(plugin, Runnable { update() }, 0, 1)
+        plugin.server.scheduler.runTaskTimer(plugin, Runnable { state.update() }, 0, 1)
     }
 
-    private fun update() {
-        if (target != null) {
-            entity.pathfinder.moveTo(target!!, speed)
-            if (attack && entity.location.distance(target!!.location) <= 3) {
-                entity.attack(target!!)
-            }
-        } else {
-            entity.pathfinder.stopPathfinding()
-        }
+
+    fun tryAttack(target: Entity): Boolean {
+        entity.lookAt(target)
+        if (entity.location.distance(target.location) >= handLength) return false
+        entity.attack(target)
+        return true
+    }
+
+    fun moveTo(target: Location) {
+        entity.lookAt(target)
+        entity.pathfinder.moveTo(target, speed)
+    }
+    fun moveStop() {
+        entity.pathfinder.stopPathfinding()
+    }
+
+    fun setInvisible(visible: Boolean) {
+        entity.isInvisible = visible
+    }
+
+    fun teleport(location: Location) {
+        entity.teleport(location)
+    }
+    fun distance(target: Entity): Double {
+        return entity.location.distance(target.location)
     }
 
 }

--- a/src/main/kotlin/jp/trap/conqest/game/NiteState.kt
+++ b/src/main/kotlin/jp/trap/conqest/game/NiteState.kt
@@ -1,0 +1,113 @@
+package jp.trap.conqest.game
+
+import org.bukkit.block.Block
+import org.bukkit.entity.LivingEntity
+import org.bukkit.plugin.Plugin
+
+enum class NiteStates {
+    FOLLOW_MASTER,
+    STATION_DISTRICT,
+    GUARD_DISTRICT,
+    ATTACK,
+    ATTACK_CORE,
+    EARN_COIN,
+    DEAD,
+}
+
+sealed class NiteState(val plugin: Plugin, val nite: Nite<*>) {
+
+    abstract val type: NiteStates
+
+    open fun update() {}
+
+    class FollowMaster(plugin: Plugin, nite: Nite<*>, override val type: NiteStates = NiteStates.FOLLOW_MASTER) :
+        NiteState(plugin, nite) {
+        private val nearDistance = 5
+
+        override fun update() {
+            if (nite.distance(nite.master) >= nearDistance)
+                nite.moveTo(nite.master.location)
+            else
+                nite.moveStop()
+        }
+    }
+
+    class StationDistrict(plugin: Plugin, nite: Nite<*>, override val type: NiteStates = NiteStates.STATION_DISTRICT) :
+        NiteState(plugin, nite) {
+
+        override fun update() {
+            // TODO 領土内を歩き回る
+        }
+    }
+
+    class GuardDistrict(plugin: Plugin, nite: Nite<*>, override val type: NiteStates = NiteStates.GUARD_DISTRICT) :
+        NiteState(plugin, nite) {
+        override fun update() {
+            // TODO 敵が領土内にいる場合、敵を攻撃 / いなくなったらStationDistrictへ
+        }
+    }
+
+    class Attack(
+        plugin: Plugin,
+        nite: Nite<*>,
+        private val target: LivingEntity,
+        override val type: NiteStates = NiteStates.ATTACK
+    ) :
+        NiteState(plugin, nite) {
+        override fun update() {
+            if (target.isDead) {
+                nite.state = FollowMaster(plugin, nite)
+            }
+            nite.moveTo(target.location)
+            nite.tryAttack(target)
+        }
+    }
+
+    class AttackCore(
+        plugin: Plugin,
+        nite: Nite<*>,
+        private val target: Block,
+        override val type: NiteStates = NiteStates.ATTACK_CORE
+    ) :
+        NiteState(plugin, nite) {
+        override fun update() {
+            if (target.isEmpty) {
+                nite.state = FollowMaster(plugin, nite)
+            }
+            nite.moveTo(target.location)
+            // TODO ブロック破壊
+        }
+    }
+
+    class EarnCoin(plugin: Plugin, nite: Nite<*>, override val type: NiteStates = NiteStates.EARN_COIN) :
+        NiteState(plugin, nite) {
+        private val respawnDelay: Long = 30
+
+        init {
+            nite.setInvisible(true)
+            nite.master.sendMessage(nite.name + "はコイン収集を開始しました")
+            plugin.server.scheduler.runTaskLater(plugin, Runnable {
+                nite.setInvisible(false)
+                nite.teleport(nite.master.location)
+                nite.master.sendMessage(nite.name + "が復活しました")
+                nite.state = FollowMaster(plugin, nite)
+            }, respawnDelay * 20)
+        }
+    }
+
+    class Dead(plugin: Plugin, nite: Nite<*>, override val type: NiteStates = NiteStates.DEAD) :
+        NiteState(plugin, nite) {
+        private val respawnDelay: Long = 30
+
+        init {
+            nite.setInvisible(true)
+            plugin.server.scheduler.runTaskLater(plugin, Runnable {
+                nite.setInvisible(false)
+                nite.teleport(nite.master.location)
+                nite.master.sendMessage(nite.name + "が復活しました")
+                nite.state = FollowMaster(plugin, nite)
+            }, respawnDelay * 20)
+        }
+    }
+
+}

--- a/src/main/kotlin/jp/trap/conqest/game/nite/NormalNite.kt
+++ b/src/main/kotlin/jp/trap/conqest/game/nite/NormalNite.kt
@@ -3,8 +3,9 @@ package jp.trap.conqest.game.nite
 import jp.trap.conqest.game.Nite
 import org.bukkit.Location
 import org.bukkit.entity.EntityType
+import org.bukkit.entity.Player
 import org.bukkit.entity.Villager
 import org.bukkit.plugin.Plugin
 
-class NormalNite(location: Location, name: String, plugin: Plugin) :
-    Nite<Villager>(location, EntityType.VILLAGER, name, plugin)
+class NormalNite(location: Location, override val name: String = "ノーマル", master: Player, plugin: Plugin) :
+    Nite<Villager>(location, EntityType.VILLAGER, name, master, plugin)

--- a/src/main/kotlin/jp/trap/conqest/listeners/ListenerNiteControl.kt
+++ b/src/main/kotlin/jp/trap/conqest/listeners/ListenerNiteControl.kt
@@ -1,0 +1,31 @@
+package jp.trap.conqest.listeners
+
+import io.papermc.paper.event.player.PrePlayerAttackEntityEvent
+import jp.trap.conqest.game.GameManager
+import jp.trap.conqest.game.NiteState
+import jp.trap.conqest.game.NiteStates
+import org.bukkit.entity.Entity
+import org.bukkit.entity.LivingEntity
+import org.bukkit.entity.Player
+import org.bukkit.event.EventHandler
+import org.bukkit.event.Listener
+import org.bukkit.event.player.PlayerInteractEntityEvent
+
+class ListenerNiteControl(private val gameManager: GameManager) : Listener {
+    private fun onClickEntity(player: Player, target: Entity) {
+        if (target !is LivingEntity) return
+        gameManager.getNites(player)
+            .filter { nite -> nite.state.type == NiteStates.FOLLOW_MASTER || nite.state.type == NiteStates.ATTACK }
+            .forEach { nite -> nite.state = NiteState.Attack(gameManager.plugin, nite, target) }
+    }
+
+    @EventHandler
+    fun onRightClick(event: PlayerInteractEntityEvent) {
+        onClickEntity(event.player, event.rightClicked)
+    }
+
+    @EventHandler
+    fun onLeftClick(event: PrePlayerAttackEntityEvent) {
+        onClickEntity(event.player, event.attacked)
+    }
+}

--- a/src/main/kotlin/jp/trap/conqest/listeners/Listeners.kt
+++ b/src/main/kotlin/jp/trap/conqest/listeners/Listeners.kt
@@ -11,6 +11,7 @@ class Listeners(
         Bukkit.getPluginManager().registerEvents(listener, plugin)
     }
     fun init(): Result<Unit> {
+        registerListener(ListenerNiteControl(plugin.gameManager))
         return Result.success(Unit)
     }
 }


### PR DESCRIPTION
Stateを切り替えることで動作を切り替えます

現在、FollowMasterとAttackを試せるように実装されています

- FollowMaster
  - プレイヤーに接近し、距離5mまで近づいたら停止(適当)
- StationDistrict
  - 領土を歩き回る予定
  - 未実装
- GuardDistrict
  - 領土を守る(ために敵を攻撃する)予定
  - 敵が領土外へ移動 or 死亡 でStationDistrictへ遷移
  - 未実装
- Attack
  - プレイヤーの指示による攻撃、プレイヤーがLivingEntityを右or左クリックでターゲット指定
  - ターゲットに無限に接近して3m以内ならダメージを与える(適当)
  - ターゲットの死亡でFollowMasterへ遷移
- AttackCore
  - プレイヤーの指示でコアを破壊予定
  - コア破壊でFollowMasterへ遷移
  - 未実装
- EarnCoin
  - コインを収集 見えなくなり、30秒後にFollowMasterへ遷移
  - 仮実装
- Dead
  - 死亡 見えなくなり、30秒後にFollowMasterへ遷移
  - 仮実装