### PR TITLE
FieldをFieldGeneratorに・District追加

### DIFF
--- a/src/main/kotlin/jp/trap/conqest/commands/CommandConQest.kt
+++ b/src/main/kotlin/jp/trap/conqest/commands/CommandConQest.kt
@@ -27,7 +27,11 @@ class CommandConQest(val plugin: Main) : Commands.Command {
                 0
             }.then(
                 io.papermc.paper.command.brigadier.Commands.literal("join").executes { ctx ->
-                    plugin.gameManager.requestOpeningGame().executeCommand(GameCommand.JOIN, ctx.source.sender)
+                    plugin.gameManager.requestOpeningGame()?.executeCommand(GameCommand.JOIN, ctx.source.sender)
+                        ?: run {
+                            ctx.source.sender.sendMessage("現在、空いているフィールドがないため、ゲームを開始できません")
+                        }
+                    0
                 }
             )
             .then(

--- a/src/main/kotlin/jp/trap/conqest/commands/CommandGenerate.kt
+++ b/src/main/kotlin/jp/trap/conqest/commands/CommandGenerate.kt
@@ -6,7 +6,7 @@ import com.mojang.brigadier.Command
 import com.mojang.brigadier.tree.LiteralCommandNode
 import io.papermc.paper.command.brigadier.CommandSourceStack
 import jp.trap.conqest.Main
-import jp.trap.conqest.game.FieldPreview
+import jp.trap.conqest.game.FieldGenerator
 import jp.trap.conqest.util.Partition
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.format.NamedTextColor
@@ -15,7 +15,7 @@ import io.papermc.paper.command.brigadier.Commands as BrigadierCommands
 
 class CommandGenerate(val plugin: Main) : Commands.Command {
 
-    private val previews = mutableMapOf<UUID, FieldPreview>()
+    private val previews = mutableMapOf<UUID, FieldGenerator>()
 
     private fun setPreview(source: CommandSourceStack, partition: Partition): Int {
         val creatorId = source.executor?.uniqueId ?: UUID(0, 0)
@@ -27,7 +27,7 @@ class CommandGenerate(val plugin: Main) : Commands.Command {
             }
             return 0
         }
-        previews[creatorId] = FieldPreview(plugin, creatorId, source.location, partition)
+        previews[creatorId] = FieldGenerator(plugin, creatorId, source.location, partition)
 
         with(source.sender) {
             sendMessage(Component.text("If you want to cancel, type /generate cancel", NamedTextColor.DARK_GREEN))

--- a/src/main/kotlin/jp/trap/conqest/commands/CommandGenerate.kt
+++ b/src/main/kotlin/jp/trap/conqest/commands/CommandGenerate.kt
@@ -6,7 +6,7 @@ import com.mojang.brigadier.Command
 import com.mojang.brigadier.tree.LiteralCommandNode
 import io.papermc.paper.command.brigadier.CommandSourceStack
 import jp.trap.conqest.Main
-import jp.trap.conqest.game.Field
+import jp.trap.conqest.game.FieldPreview
 import jp.trap.conqest.util.Partition
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.format.NamedTextColor
@@ -15,7 +15,7 @@ import io.papermc.paper.command.brigadier.Commands as BrigadierCommands
 
 class CommandGenerate(val plugin: Main) : Commands.Command {
 
-    private val previews = mutableMapOf<UUID, Field>()
+    private val previews = mutableMapOf<UUID, FieldPreview>()
 
     private fun setPreview(source: CommandSourceStack, partition: Partition): Int {
         val creatorId = source.executor?.uniqueId ?: UUID(0, 0)
@@ -27,7 +27,7 @@ class CommandGenerate(val plugin: Main) : Commands.Command {
             }
             return 0
         }
-        previews[creatorId] = Field(plugin, creatorId, source.location, partition)
+        previews[creatorId] = FieldPreview(plugin, creatorId, source.location, partition)
 
         with(source.sender) {
             sendMessage(Component.text("If you want to cancel, type /generate cancel", NamedTextColor.DARK_GREEN))
@@ -81,17 +81,17 @@ class CommandGenerate(val plugin: Main) : Commands.Command {
     private fun confirm(source: CommandSourceStack): Int {
         val creatorId = source.executor?.uniqueId ?: UUID(0, 0)
 
-        val field = previews[creatorId] ?: run {
+        val fieldPreview = previews[creatorId] ?: run {
             source.sender.sendMessage(Component.text("Need to preview first!", NamedTextColor.RED))
             return 0
         }
-        field.generate()
-        plugin.gameManager.addField(field)
+        
+        plugin.gameManager.addField(fieldPreview.generate())
         previews.remove(creatorId)
 
         with(source.sender) {
             sendMessage(Component.text("=".repeat(40), NamedTextColor.GREEN))
-            sendMessage(Component.text("The field has been generated at ${field.center}!"))
+            sendMessage(Component.text("The field has been generated at ${fieldPreview.center}!"))
             sendMessage(Component.text("=".repeat(40), NamedTextColor.GREEN))
         }
         return Command.SINGLE_SUCCESS

--- a/src/main/kotlin/jp/trap/conqest/game/District.kt
+++ b/src/main/kotlin/jp/trap/conqest/game/District.kt
@@ -1,0 +1,13 @@
+package jp.trap.conqest.game
+
+import org.bukkit.Location
+import org.bukkit.scoreboard.Team
+
+class District(private val locations: Set<Pair<Int, Int>>, private val coreLocation: Location, private var team: Team? = null) {
+    fun setTeam(team: Team) {
+        this.team = team
+    }
+    fun contains(location: Pair<Int, Int>): Boolean {
+        return location in locations
+    }
+}

--- a/src/main/kotlin/jp/trap/conqest/game/Field.kt
+++ b/src/main/kotlin/jp/trap/conqest/game/Field.kt
@@ -13,11 +13,9 @@ class Field(
     init {
         val districtCount = partition.districts.size
         val locations: MutableList<MutableSet<Pair<Int, Int>>> = MutableList(size = districtCount) { mutableSetOf() }
-        val centerList = MutableList(size = districtCount) { 0 to 0 }
         for (x in 0 until partition.fieldSize.first) for (y in 0 until partition.fieldSize.second) {
             val idx = partition.getDistrictIndex(x to y)!!
             locations[idx].add(x to y)
-            if (partition.isCenter(x to y)) centerList[idx] = x to y
         }
         districts = (0 until districtCount).map { i -> District(locations[i], coreLocations[i]) }
     }

--- a/src/main/kotlin/jp/trap/conqest/game/Field.kt
+++ b/src/main/kotlin/jp/trap/conqest/game/Field.kt
@@ -1,171 +1,34 @@
 package jp.trap.conqest.game
 
-import jp.trap.conqest.Main
 import jp.trap.conqest.util.Partition
-import net.kyori.adventure.text.Component
-import net.kyori.adventure.text.format.NamedTextColor
-import org.bukkit.Bukkit
 import org.bukkit.Location
-import org.bukkit.Material
-import org.bukkit.Tag
-import org.bukkit.block.data.BlockData
-import org.bukkit.entity.Player
-import java.util.*
 
 class Field(
-    val plugin: Main, val creatorId: UUID, val center: Location, val partition: Partition, val roadWidth: Double = 3.0
+    private val center: Location,
+    partition: Partition,
+    private val coreLocations: List<Location>
 ) {
-
-    object Materials {
-        val wall = Material.BEDROCK
-        val core = Material.BEACON
-        val coreBase = Material.IRON_BLOCK
-        val fence = Material.STONE_BRICK_WALL
-        val road = Material.DIRT_PATH
-    }
-
-    private val blockChanges = mutableMapOf<Location, BlockData>()
+    private val districts: List<District>
 
     init {
-        require(roadWidth > 0.0) { "roadWidth must be positive" }
-
-        Bukkit.getPlayer(creatorId)?.let { showPreview(it) }
+        val districtCount = partition.districts.size
+        val locations: MutableList<MutableSet<Pair<Int, Int>>> = MutableList(size = districtCount) { mutableSetOf() }
+        val centerList = MutableList(size = districtCount) { 0 to 0 }
+        for (x in 0 until partition.fieldSize.first) for (y in 0 until partition.fieldSize.second) {
+            val idx = partition.getDistrictIndex(x to y)!!
+            locations[idx].add(x to y)
+            if (partition.isCenter(x to y)) centerList[idx] = x to y
+        }
+        districts = (0 until districtCount).map { i -> District(locations[i], coreLocations[i]) }
     }
 
-    fun bottom(): Int = center.blockX - partition.fieldSize.first / 2
+    private val size: Pair<Int, Int> = partition.fieldSize
 
-    fun top(): Int = bottom() + partition.fieldSize.first
-
-    fun left(): Int = center.blockZ - partition.fieldSize.second / 2
-
-    fun right(): Int = left() + partition.fieldSize.second
-
-    fun showPreview(target: Player) {
-        hidePreview()
-
-        // wall
-        forEachGrounds(target) { position, ground ->
-            if (partition.getDistrictIndex(position) != null) return@forEachGrounds
-            ground.y = target.world.minHeight.toDouble()
-            while (ground.y <= target.world.maxHeight) {
-                blockChanges[ground.clone()] = Materials.wall.createBlockData()
-                ground.y += 1.0
-            }
-        }
-
-        // remove tree
-        forEachGrounds(target) { _, ground ->
-            while (ground.blockY - 1 >= target.world.minHeight) {
-                val material = getChangedBlockData(ground).material
-                if (checkIsTree(material)) {
-                    blockChanges[ground.clone()] = Material.AIR.createBlockData()
-                } else if (material.isCollidable) break
-                ground.y -= 1.0
-            }
-        }
-
-        // cover liquid with glass
-        forEachGrounds(target) { _, ground ->
-            when (getChangedBlockData(ground).material) {
-                Material.WATER -> blockChanges[ground] = Material.LIGHT_BLUE_STAINED_GLASS.createBlockData()
-                Material.LAVA -> blockChanges[ground] = Material.ORANGE_STAINED_GLASS.createBlockData()
-                else -> {}
-            }
-        }
-
-        // road
-        forEachGrounds(target) { position, ground ->
-            if (!partition.inRoad(position, roadWidth)) return@forEachGrounds
-            blockChanges[ground] = Materials.road.createBlockData()
-        }
-
-        // fence
-        forEachGrounds(target) { position, ground ->
-            if (partition.getDistrictIndex(position) == null) return@forEachGrounds
-            for (x in -2..2) for (z in -2..2) {
-                val pos = position.first + x to position.second + z
-                if (partition.getBorderLevel(pos) < 1) continue
-                if (partition.inRoad(pos, roadWidth)) continue
-                val loc = ground.clone().add(x.toDouble(), 1.0, z.toDouble())
-                while (loc.blockY >= target.world.minHeight) {
-                    if (!getChangedBlockData(loc).material.isCollidable) {
-                        blockChanges[loc.clone()] = Materials.fence.createBlockData()
-                    }
-                    loc.y -= 1.0
-                }
-            }
-        }
-
-        // core
-        forEachGrounds(target) { position, ground ->
-            if (!partition.isCenter(position)) return@forEachGrounds
-            val coreLoc = ground.add(0.0, 1.0, 0.0)
-            for (x in -1..1) for (z in -1..1) {
-                blockChanges[coreLoc.clone().add(x.toDouble(), -1.0, z.toDouble())] =
-                    Materials.coreBase.createBlockData()
-            }
-            blockChanges[coreLoc] = Materials.core.createBlockData()
-        }
-
-        target.sendMultiBlockChange(blockChanges)
-        with(target) {
-            sendMessage(Component.text("-".repeat(40), NamedTextColor.GREEN))
-            sendMessage(Component.text("Previewing at $center"))
-            sendMessage(Component.text("  X: ${bottom()} to ${top()}"))
-            sendMessage(Component.text("  Z: ${left()} to ${right()}"))
-            sendMessage(Component.text("-".repeat(40), NamedTextColor.GREEN))
-        }
+    fun getDistrict(location: Pair<Int, Int>): District? {
+        return districts.singleOrNull { district: District -> district.contains(location) }
     }
 
-    fun hidePreview() {
-        blockChanges.keys.forEach { it.block.state.update(false, false) }
-        blockChanges.clear()
+    fun getDistrict(location: Location): District? {
+        return getDistrict(location.blockX to location.blockZ)
     }
-
-    fun generate() {
-        blockChanges.forEach { (loc, data) ->
-            loc.block.blockData = data
-            loc.block.state.update(true, false)
-            if (data.material == Materials.core) {
-                // TODO: this.cores[partition.getDistrictIndex(loc.blockX to loc.blockZ)] にコアの座標を設定
-            }
-        }
-
-        with(plugin.logger) {
-            info("-".repeat(40))
-            info("Field generated by $creatorId")
-            info("  X: ${bottom()} to ${top()}")
-            info("  Z: ${left()} to ${right()}")
-            partition.toString(roadWidth).split("\n").forEach { info(it) }
-            info("-".repeat(40))
-        }
-    }
-
-    private fun checkIsTree(material: Material): Boolean {
-        return Tag.LOGS.isTagged(material) || Tag.LEAVES.isTagged(material) || material == Material.BEE_NEST
-    }
-
-    private fun getChangedBlockData(loc: Location): BlockData = blockChanges[loc.clone()] ?: loc.block.blockData.clone()
-
-    private fun forEachGrounds(
-        target: Player, action: (position: Pair<Int, Int>, ground: Location) -> Unit
-    ) {
-        for (i in -1 until partition.fieldSize.first + 1) {
-            for (j in -1 until partition.fieldSize.second + 1) {
-                val ground = target.world.getHighestBlockAt(bottom() + i, left() + j).location
-                if (ground.blockY + 1 <= target.world.maxHeight) {
-                    ground.y += 1.0
-                }
-                while (ground.blockY - 1 >= target.world.minHeight) {
-                    val material = getChangedBlockData(ground).material
-                    if (material.isCollidable && material != Materials.fence) break
-                    // TODO: 水に浸かっているいる水でないブロックに対応
-                    if (material == Material.WATER || material == Material.LAVA) break
-                    ground.y -= 1.0
-                }
-                action(i to j, ground)
-            }
-        }
-    }
-
 }

--- a/src/main/kotlin/jp/trap/conqest/game/FieldGenerator.kt
+++ b/src/main/kotlin/jp/trap/conqest/game/FieldGenerator.kt
@@ -12,7 +12,7 @@ import org.bukkit.block.data.BlockData
 import org.bukkit.entity.Player
 import java.util.*
 
-class FieldPreview(
+class FieldGenerator(
     val plugin: Main, val creatorId: UUID, val center: Location, val partition: Partition, val roadWidth: Double = 3.0
 ) {
 

--- a/src/main/kotlin/jp/trap/conqest/game/FieldPreview.kt
+++ b/src/main/kotlin/jp/trap/conqest/game/FieldPreview.kt
@@ -1,0 +1,184 @@
+package jp.trap.conqest.game
+
+import jp.trap.conqest.Main
+import jp.trap.conqest.util.Partition
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.format.NamedTextColor
+import org.bukkit.Bukkit
+import org.bukkit.Location
+import org.bukkit.Material
+import org.bukkit.Tag
+import org.bukkit.block.data.BlockData
+import org.bukkit.entity.Player
+import java.util.*
+
+class FieldPreview(
+    val plugin: Main, val creatorId: UUID, val center: Location, val partition: Partition, val roadWidth: Double = 3.0
+) {
+
+    object Materials {
+        val wall = Material.BEDROCK
+        val core = Material.BEACON
+        val coreBase = Material.IRON_BLOCK
+        val fence = Material.STONE_BRICK_WALL
+        val road = Material.DIRT_PATH
+    }
+
+    private val blockChanges = mutableMapOf<Location, BlockData>()
+
+    private val coreLocations: MutableList<Location> = mutableListOf()
+
+    init {
+        require(roadWidth > 0.0) { "roadWidth must be positive" }
+
+        Bukkit.getPlayer(creatorId)?.let { showPreview(it) }
+    }
+
+    fun bottom(): Int = center.blockX - partition.fieldSize.first / 2
+
+    fun top(): Int = bottom() + partition.fieldSize.first
+
+    fun left(): Int = center.blockZ - partition.fieldSize.second / 2
+
+    fun right(): Int = left() + partition.fieldSize.second
+
+    fun showPreview(target: Player) {
+        hidePreview()
+
+        // wall
+        forEachGrounds(target) { position, ground ->
+            if (partition.getDistrictIndex(position) != null) return@forEachGrounds
+            ground.y = target.world.minHeight.toDouble()
+            while (ground.y <= target.world.maxHeight) {
+                blockChanges[ground.clone()] = Materials.wall.createBlockData()
+                ground.y += 1.0
+            }
+        }
+
+        // remove tree
+        forEachGrounds(target) { _, ground ->
+            while (ground.blockY - 1 >= target.world.minHeight) {
+                val material = getChangedBlockData(ground).material
+                if (checkIsTree(material)) {
+                    blockChanges[ground.clone()] = Material.AIR.createBlockData()
+                } else if (material.isCollidable) break
+                ground.y -= 1.0
+            }
+        }
+
+        // cover liquid with glass
+        forEachGrounds(target) { _, ground ->
+            when (getChangedBlockData(ground).material) {
+                Material.WATER -> blockChanges[ground] = Material.LIGHT_BLUE_STAINED_GLASS.createBlockData()
+                Material.LAVA -> blockChanges[ground] = Material.ORANGE_STAINED_GLASS.createBlockData()
+                else -> {}
+            }
+        }
+
+        // road
+        forEachGrounds(target) { position, ground ->
+            if (!partition.inRoad(position, roadWidth)) return@forEachGrounds
+            blockChanges[ground] = Materials.road.createBlockData()
+        }
+
+        // fence
+        forEachGrounds(target) { position, ground ->
+            if (partition.getDistrictIndex(position) == null) return@forEachGrounds
+            for (x in -2..2) for (z in -2..2) {
+                val pos = position.first + x to position.second + z
+                if (partition.getBorderLevel(pos) < 1) continue
+                if (partition.inRoad(pos, roadWidth)) continue
+                val loc = ground.clone().add(x.toDouble(), 1.0, z.toDouble())
+                while (loc.blockY >= target.world.minHeight) {
+                    if (!getChangedBlockData(loc).material.isCollidable) {
+                        blockChanges[loc.clone()] = Materials.fence.createBlockData()
+                    }
+                    loc.y -= 1.0
+                }
+            }
+        }
+
+        // core
+        val coreLocationSet: MutableSet<Location> = mutableSetOf()
+        forEachGrounds(target) { position, ground ->
+            if (!partition.isCenter(position)) return@forEachGrounds
+            val coreLoc = ground.add(0.0, 1.0, 0.0)
+            for (x in -1..1) for (z in -1..1) {
+                blockChanges[coreLoc.clone().add(x.toDouble(), -1.0, z.toDouble())] =
+                    Materials.coreBase.createBlockData()
+            }
+            blockChanges[coreLoc] = Materials.core.createBlockData()
+            coreLocationSet.add(coreLoc)
+        }
+        coreLocations.clear()
+        (0 until partition.districts.size).forEach { idx ->
+            val district = partition.districts[idx]
+            coreLocations.add(coreLocationSet.single { loc ->
+                district.center.first.toInt() == loc.blockX && district.center.second.toInt() == loc.blockY
+            })
+        }
+
+        target.sendMultiBlockChange(blockChanges)
+        with(target) {
+            sendMessage(Component.text("-".repeat(40), NamedTextColor.GREEN))
+            sendMessage(Component.text("Previewing at $center"))
+            sendMessage(Component.text("  X: ${bottom()} to ${top()}"))
+            sendMessage(Component.text("  Z: ${left()} to ${right()}"))
+            sendMessage(Component.text("-".repeat(40), NamedTextColor.GREEN))
+        }
+    }
+
+    fun hidePreview() {
+        blockChanges.keys.forEach { it.block.state.update(false, false) }
+        blockChanges.clear()
+    }
+
+    fun generate(): Field {
+        blockChanges.forEach { (loc, data) ->
+            loc.block.blockData = data
+            loc.block.state.update(true, false)
+            if (data.material == Materials.core) {
+                // TODO: this.cores[partition.getDistrictIndex(loc.blockX to loc.blockZ)] にコアの座標を設定
+            }
+        }
+
+        with(plugin.logger) {
+            info("-".repeat(40))
+            info("Field generated by $creatorId")
+            info("  X: ${bottom()} to ${top()}")
+            info("  Z: ${left()} to ${right()}")
+            partition.toString(roadWidth).split("\n").forEach { info(it) }
+            info("-".repeat(40))
+        }
+
+        return Field(center, partition, coreLocations)
+    }
+
+    private fun checkIsTree(material: Material): Boolean {
+        return Tag.LOGS.isTagged(material) || Tag.LEAVES.isTagged(material) || material == Material.BEE_NEST
+    }
+
+    private fun getChangedBlockData(loc: Location): BlockData = blockChanges[loc.clone()] ?: loc.block.blockData.clone()
+
+    private fun forEachGrounds(
+        target: Player, action: (position: Pair<Int, Int>, ground: Location) -> Unit
+    ) {
+        for (i in -1 until partition.fieldSize.first + 1) {
+            for (j in -1 until partition.fieldSize.second + 1) {
+                val ground = target.world.getHighestBlockAt(bottom() + i, left() + j).location
+                if (ground.blockY + 1 <= target.world.maxHeight) {
+                    ground.y += 1.0
+                }
+                while (ground.blockY - 1 >= target.world.minHeight) {
+                    val material = getChangedBlockData(ground).material
+                    if (material.isCollidable && material != Materials.fence) break
+                    // TODO: 水に浸かっているいる水でないブロックに対応
+                    if (material == Material.WATER || material == Material.LAVA) break
+                    ground.y -= 1.0
+                }
+                action(i to j, ground)
+            }
+        }
+    }
+
+}

--- a/src/main/kotlin/jp/trap/conqest/game/FieldPreview.kt
+++ b/src/main/kotlin/jp/trap/conqest/game/FieldPreview.kt
@@ -137,9 +137,6 @@ class FieldPreview(
         blockChanges.forEach { (loc, data) ->
             loc.block.blockData = data
             loc.block.state.update(true, false)
-            if (data.material == Materials.core) {
-                // TODO: this.cores[partition.getDistrictIndex(loc.blockX to loc.blockZ)] にコアの座標を設定
-            }
         }
 
         with(plugin.logger) {

--- a/src/main/kotlin/jp/trap/conqest/game/FieldPreview.kt
+++ b/src/main/kotlin/jp/trap/conqest/game/FieldPreview.kt
@@ -112,9 +112,8 @@ class FieldPreview(
         }
         coreLocations.clear()
         (0 until partition.districts.size).forEach { idx ->
-            val district = partition.districts[idx]
             coreLocations.add(coreLocationSet.single { loc ->
-                district.center.first.toInt() == loc.blockX && district.center.second.toInt() == loc.blockY
+                partition.getDistrictIndex(loc.blockX - bottom() to loc.blockZ - left()) == idx
             })
         }
 

--- a/src/main/kotlin/jp/trap/conqest/game/Game.kt
+++ b/src/main/kotlin/jp/trap/conqest/game/Game.kt
@@ -6,7 +6,7 @@ import org.bukkit.entity.Player
 import org.bukkit.plugin.Plugin
 import java.util.*
 
-class Game(val plugin: Plugin) {
+class Game(val plugin: Plugin, val field: Field) {
 
     private var state: GameState = GameState.BeforeGame(this)
     private val players: MutableList<Player> = mutableListOf()

--- a/src/main/kotlin/jp/trap/conqest/game/GameManager.kt
+++ b/src/main/kotlin/jp/trap/conqest/game/GameManager.kt
@@ -6,14 +6,19 @@ import org.bukkit.plugin.Plugin
 class GameManager(val plugin: Plugin) {
     private val games: MutableList<Game> = mutableListOf()
     private val fields: MutableList<Field> = mutableListOf()
-    fun requestOpeningGame(): Game {
+    fun requestOpeningGame(): Game? {
         return games.firstOrNull { game -> game.getStateType() == GameStates.MATCHING }
-            ?: games.firstOrNull { game -> game.getStateType() == GameStates.BEFORE_GAME }
-            ?: run {
-                val newGame = Game(plugin)
-                games.add(newGame)
-                newGame
+            ?: games.firstOrNull { game -> game.getStateType() == GameStates.BEFORE_GAME } ?: run {
+                requestOpeningField()?.let { field ->
+                    val newGame = Game(plugin, field)
+                    games += newGame
+                    newGame
+                }
             }
+    }
+
+    private fun requestOpeningField(): Field? {
+        return fields.firstOrNull { field -> games.all { game -> game.field != field } }
     }
 
     fun getGame(player: Player): Game? {

--- a/src/main/kotlin/jp/trap/conqest/game/Team.kt
+++ b/src/main/kotlin/jp/trap/conqest/game/Team.kt
@@ -1,0 +1,4 @@
+package jp.trap.conqest.game
+
+class Team {
+}


### PR DESCRIPTION
Fieldという名前のクラスについて、実際にフィールドを生成する前の(パターン生成→プレビューのための)処理が多いと感じたので、これをFieldPreviewに改名し、generate()がFieldクラス(新)を返すようにしました。
また、Fieldより狭い概念であるDistrictクラスを作成しました。
Partitionクラスは生成用であると考え、このデータへの依存を避けたかったため、領土の分布は領域内を全探索して求めるようにしています。

## 以下AI要約

このプル リクエストでは、ゲーム フィールドの生成と管理機能の強化に重点を置いた、`jp.trap.conqest` プロジェクトへのいくつかの重要な変更が導入されています。変更には、コマンド処理の変更、フィールド生成ロジックのリファクタリング、構造と機能を向上させるための新しいクラスの導入が含まれます。

### コマンド処理の改善:
* [`src/main/kotlin/jp/trap/conqest/commands/CommandConQest.kt`](diffhunk://#diff-5c0308d5ace630e0c4800afad60834a319010ca7a79574f72aca522d954dd2aeL30-R34): 「join」コマンドの実行時に null チェックを追加し、開いているゲーム フィールドがない場合にユーザー フレンドリなメッセージを提供するようにしました。
> ZOI注: nullチェックを追加したというより、フィールド制度と結合したことで「空きフィールドがない」というエラーが発生するようになった

### フィールド生成のリファクタリング:
* [`src/main/kotlin/jp/trap/conqest/commands/CommandGenerate.kt`](diffhunk://#diff-003908b1b8a1166e962b7f3ce2b278cf09b06b711a94a67d389be87c195dad55L9-R9): プレビュー用に `Field` タイプを `FieldPreview` に置き換え、関連するロジックを `FieldPreview` を使用するように更新しました。 [[1]](diffhunk://#diff-003908b1b8a1166e962b7f3ce2b278cf09b06b711a94a67d389be87c195dad55L9-R9) [[2]](diffhunk://#diff-003908b1b8a1166e962b7f3ce2b278cf09b06b711a94a67d389be87c195dad55L18-R18) [[3]](diffhunk://#diff-003908b1b8a1166e962b7f3ce2b278cf09b06b711a94a67d389be87c195dad55L30-R30) [[4]](diffhunk://#diff-003908b1b8a1166e962b7f3ce2b278cf09b06b711a94a67d389be87c195dad55L84-R94)
* [`src/main/kotlin/jp/trap/conqest/game/Field.kt`](diffhunk://#diff-dd29ff1c8f750ca8952ba6c5cba747eb74c7cde98f07913d88b1d28fd71681edL3-L170): プレビュー関連のロジックを削除し、地区とコアロケーションの管理に重点を置くように `Field` クラスをリファクタリングしました。
> ZOI注: Fieldをリファクタしたというより、新Fieldクラスは新しく作成されたと考えた方が良い

* [`src/main/kotlin/jp/trap/conqest/game/FieldPreview.kt`​​](diffhunk://#diff-7e5ded8d83bc2cfb11e315ad2fd67a34ff1fb2cf424925c577ccd76dacbd36a7R1-R181): メインの `Field` クラスとは別にフィールド プレビュー ロジックを処理する新しい `FieldPreview` クラスを導入しました。
> ZOI注: FieldPreviewは旧Fieldを名前変更したものなので導入とはちょっと違う

### ゲーム管理の機能強化:
* [`src/main/kotlin/jp/trap/conqest/game/Game.kt`](diffhunk://#diff-b6c1bcb3b7dd61aa4f038ec22cb244dc5c4f7f6c73eac26e9e1276558f65162dL9-R9): 使用されている `Field` への参照が含まれるように `Game` クラスを更新しました。
* [`src/main/kotlin/jp/trap/conqest/game/GameManager.kt`](diffhunk://#diff-53bb18424fb6854de466c9bdb4655c3292ca591b8bbd12ea25f57c1b50af0f90L9-R22): 新しいゲームを作成するときにフィールドの割り当てを処理するように `GameManager` を変更し、ゲームが利用可能なフィールドに割り当てられるようにしました。

### 新しいクラスの紹介:
* [`src/main/kotlin/jp/trap/conqest/game/District.kt`](diffhunk://#diff-cc97a5417bb9369741ab84f093a155defa5d6147507335af1ddeda1f04056541R1-R13): チームの割り当てや場所のチェックなど、フィールド内の個々の地区を表す新しい `District` クラスを追加しました。
* [`src/main/kotlin/jp/trap/conqest/game/Team.kt`](diffhunk://#diff-02157145cd2dfdfe8e6b7676174d52f86d0c813623a712a3b214c4bca42518ebR1-R4): 新しい `Team` クラスを導入しましたが、現在は実装されていません。