### PR TITLE
Niteの動作の不具合を修正

### DIFF
--- a/src/main/kotlin/jp/trap/conqest/game/Game.kt
+++ b/src/main/kotlin/jp/trap/conqest/game/Game.kt
@@ -41,12 +41,19 @@ class Game(val plugin: Plugin) {
         return state.executeCommand(command, sender)
     }
 
+    fun getNites(): List<Nite<*>> {
+        return getPlayers().flatMap { getNites(it) }
+    }
+
     fun getNites(player: Player): List<Nite<*>> {
         return nites.computeIfAbsent(player.uniqueId) { ArrayList() }
     }
 
     fun addNite(nite: Nite<*>, master: Player) {
         nites.computeIfAbsent(master.uniqueId) { ArrayList() }.add(nite)
+    }
+    fun removeNite(nite: Nite<*>) {
+        // TODO
     }
 
     fun judge() {

--- a/src/main/kotlin/jp/trap/conqest/game/GameManager.kt
+++ b/src/main/kotlin/jp/trap/conqest/game/GameManager.kt
@@ -20,6 +20,10 @@ class GameManager(val plugin: Plugin) {
         return games.firstOrNull { game -> game.getPlayers().contains(player) }
     }
 
+    fun getGames(): List<Game> {
+        return games
+    }
+
     fun addField(field: Field) {
         fields.add(field)
     }

--- a/src/main/kotlin/jp/trap/conqest/game/Nite.kt
+++ b/src/main/kotlin/jp/trap/conqest/game/Nite.kt
@@ -7,6 +7,7 @@ import org.bukkit.entity.*
 import org.bukkit.plugin.Plugin
 import org.bukkit.potion.PotionEffect
 import org.bukkit.potion.PotionEffectType
+import java.util.*
 
 abstract class Nite<T>(location: Location, type: EntityType, name: String, val master: Player, val plugin: Plugin)
         where T : Entity, T : Mob {
@@ -41,6 +42,7 @@ abstract class Nite<T>(location: Location, type: EntityType, name: String, val m
         entity.lookAt(target)
         entity.pathfinder.moveTo(target, speed)
     }
+
     fun moveStop() {
         entity.pathfinder.stopPathfinding()
     }
@@ -52,8 +54,13 @@ abstract class Nite<T>(location: Location, type: EntityType, name: String, val m
     fun teleport(location: Location) {
         entity.teleport(location)
     }
+
     fun distance(target: Entity): Double {
         return entity.location.distance(target.location)
+    }
+
+    fun getUniqueId(): UUID {
+        return entity.uniqueId
     }
 
 }

--- a/src/main/kotlin/jp/trap/conqest/game/Nite.kt
+++ b/src/main/kotlin/jp/trap/conqest/game/Nite.kt
@@ -63,4 +63,8 @@ abstract class Nite<T>(location: Location, type: EntityType, name: String, val m
         return entity.uniqueId
     }
 
+    fun setAi(value: Boolean) {
+        entity.setAI(value)
+    }
+
 }

--- a/src/main/kotlin/jp/trap/conqest/game/Nite.kt
+++ b/src/main/kotlin/jp/trap/conqest/game/Nite.kt
@@ -9,8 +9,13 @@ import org.bukkit.potion.PotionEffect
 import org.bukkit.potion.PotionEffectType
 import java.util.*
 
-abstract class Nite<T>(location: Location, type: EntityType, name: String, val master: Player, val plugin: Plugin)
-        where T : Entity, T : Mob {
+abstract class Nite<T>(
+    location: Location,
+    type: EntityType,
+    name: String,
+    val master: Player,
+    val plugin: Plugin
+) where T : Entity, T : Mob {
     private var entity: T = location.world.spawnEntity(
         location, type, false
     ) as T
@@ -47,8 +52,16 @@ abstract class Nite<T>(location: Location, type: EntityType, name: String, val m
         entity.pathfinder.stopPathfinding()
     }
 
-    fun setInvisible(visible: Boolean) {
-        entity.isInvisible = visible
+    fun setVisible(visible: Boolean) {
+        entity.isInvisible = visible.not()
+        entity.setNoPhysics(visible.not())
+        entity.setGravity(visible)
+        entity.isCollidable = visible
+        entity.health = entity.getAttribute(Attribute.MAX_HEALTH)!!.value
+    }
+
+    fun getVisible(): Boolean {
+        return entity.isInvisible.not()
     }
 
     fun teleport(location: Location) {

--- a/src/main/kotlin/jp/trap/conqest/game/NiteState.kt
+++ b/src/main/kotlin/jp/trap/conqest/game/NiteState.kt
@@ -84,10 +84,10 @@ sealed class NiteState(val plugin: Plugin, val nite: Nite<*>) {
         private val respawnDelay: Long = 30
 
         init {
-            nite.setInvisible(true)
+            nite.setVisible(false)
             nite.master.sendMessage(nite.name + "はコイン収集を開始しました")
             plugin.server.scheduler.runTaskLater(plugin, Runnable {
-                nite.setInvisible(false)
+                nite.setVisible(true)
                 nite.teleport(nite.master.location)
                 nite.master.sendMessage(nite.name + "が復活しました")
                 nite.state = FollowMaster(plugin, nite)
@@ -100,11 +100,11 @@ sealed class NiteState(val plugin: Plugin, val nite: Nite<*>) {
         private val respawnDelay: Long = 30
 
         init {
-            nite.setInvisible(true)
+            nite.setVisible(false)
             nite.setAi(false)
             plugin.server.scheduler.runTaskLater(plugin, Runnable {
                 nite.setAi(true)
-                nite.setInvisible(false)
+                nite.setVisible(true)
                 nite.teleport(nite.master.location)
                 nite.master.sendMessage(nite.name + "が復活しました")
                 nite.state = FollowMaster(plugin, nite)

--- a/src/main/kotlin/jp/trap/conqest/game/NiteState.kt
+++ b/src/main/kotlin/jp/trap/conqest/game/NiteState.kt
@@ -101,7 +101,9 @@ sealed class NiteState(val plugin: Plugin, val nite: Nite<*>) {
 
         init {
             nite.setInvisible(true)
+            nite.setAi(false)
             plugin.server.scheduler.runTaskLater(plugin, Runnable {
+                nite.setAi(true)
                 nite.setInvisible(false)
                 nite.teleport(nite.master.location)
                 nite.master.sendMessage(nite.name + "が復活しました")

--- a/src/main/kotlin/jp/trap/conqest/listeners/ListenerNiteControl.kt
+++ b/src/main/kotlin/jp/trap/conqest/listeners/ListenerNiteControl.kt
@@ -49,7 +49,12 @@ class ListenerNiteControl(private val gameManager: GameManager) : Listener {
         gameManager.getGames().forEach { game ->
             game.getPlayers().flatMap { player -> gameManager.getGame(player)?.getNites(player) ?: emptyList() }
                 .singleOrNull { nite -> nite.getUniqueId() == event.entity.uniqueId }
-                ?.let { nite -> trySetTarget(nite, event.damager as LivingEntity) }
+                ?.let { nite ->
+                    if (nite.getVisible())
+                        trySetTarget(nite, event.damager as LivingEntity)
+                    else
+                        event.isCancelled = true
+                }
         }
     }
 

--- a/src/main/kotlin/jp/trap/conqest/listeners/ListenerNiteControl.kt
+++ b/src/main/kotlin/jp/trap/conqest/listeners/ListenerNiteControl.kt
@@ -2,6 +2,7 @@ package jp.trap.conqest.listeners
 
 import io.papermc.paper.event.player.PrePlayerAttackEntityEvent
 import jp.trap.conqest.game.GameManager
+import jp.trap.conqest.game.Nite
 import jp.trap.conqest.game.NiteState
 import jp.trap.conqest.game.NiteStates
 import org.bukkit.entity.Entity
@@ -9,14 +10,25 @@ import org.bukkit.entity.LivingEntity
 import org.bukkit.entity.Player
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
+import org.bukkit.event.entity.EntityDamageByEntityEvent
 import org.bukkit.event.player.PlayerInteractEntityEvent
 
 class ListenerNiteControl(private val gameManager: GameManager) : Listener {
+    private fun trySetTarget(nite: Nite<*>, target: LivingEntity) {
+        // プレイヤーには攻撃しない
+        if (target is Player) return
+        // 仲間のNiteには攻撃しない TODO: Player単位ではなくTeam単位で制限?
+        if (gameManager.getGame(nite.master)?.getNites(nite.master)
+                ?.any { friendNite -> friendNite.getUniqueId() == target.uniqueId } == true
+        ) return
+        // 現在、攻撃可能な状態かどうかを調べる
+        if (nite.state.type != NiteStates.FOLLOW_MASTER && nite.state.type != NiteStates.ATTACK) return
+        nite.state = NiteState.Attack(gameManager.plugin, nite, target)
+    }
+
     private fun onClickEntity(player: Player, target: Entity) {
         if (target !is LivingEntity) return
-        gameManager.getGame(player)?.getNites(player)
-            ?.filter { nite -> nite.state.type == NiteStates.FOLLOW_MASTER || nite.state.type == NiteStates.ATTACK }
-            ?.forEach { nite -> nite.state = NiteState.Attack(gameManager.plugin, nite, target) }
+        gameManager.getGame(player)?.getNites(player)?.forEach { nite -> trySetTarget(nite, target) }
     }
 
     @EventHandler
@@ -27,5 +39,15 @@ class ListenerNiteControl(private val gameManager: GameManager) : Listener {
     @EventHandler
     fun onLeftClick(event: PrePlayerAttackEntityEvent) {
         onClickEntity(event.player, event.attacked)
+    }
+
+    @EventHandler
+    fun onNiteDamagedByEntity(event: EntityDamageByEntityEvent) {
+        if (event.damager !is LivingEntity) return
+        gameManager.getGames().forEach { game ->
+            game.getPlayers().flatMap { player -> gameManager.getGame(player)?.getNites(player) ?: emptyList() }
+                .singleOrNull { nite -> nite.getUniqueId() == event.entity.uniqueId }
+                ?.let { nite -> trySetTarget(nite, event.damager as LivingEntity) }
+        }
     }
 }


### PR DESCRIPTION
fix #53, #61, #62

### Copilot

このプル リクエストでは、`jp.trap.conqest` パッケージの `Game`、`GameManager`、`Nite`、`NiteState`、および `ListenerNiteControl` クラスにいくつかの変更が導入されています。変更には、新しいメソッドの追加、既存の機能の強化、`Nite` エンティティのイベント処理の改善が含まれます。

### `Game` クラスと `GameManager` クラスの機能強化:

* [`src/main/kotlin/jp/trap/conqest/game/Game.kt`](diffhunk://#diff-b6c1bcb3b7dd61aa4f038ec22cb244dc5c4f7f6c73eac26e9e1276558f65162dR44-R57): すべての `Nite` インスタンスを取得するための `getNites()` メソッドと、将来の実装のための TODO コメント付きの `removeNite(nite: Nite<*>)` メソッドを追加しました。
* [`src/main/kotlin/jp/trap/conqest/game/GameManager.kt`](diffhunk://#diff-53bb18424fb6854de466c9bdb4655c3292ca591b8bbd12ea25f57c1b50af0f90R23-R26): すべての `Game` インスタンスを取得するための `getGames()` メソッドを追加しました。

### `Nite` クラスへの追加:

* [`src/main/kotlin/jp/trap/conqest/game/Nite.kt`](diffhunk://#diff-5eb2a924c58ea68fa77624864bd57a2308be177e297c08f5971646d81d3ec0c0R57-R69): `getUniqueId()`、`setAi(value: Boolean)`、およびその他のユーティリティ メソッドを追加して、`Nite` 機能を強化しました。
* [`src/main/kotlin/jp/trap/conqest/game/Nite.kt`](diffhunk://#diff-5eb2a924c58ea68fa77624864bd57a2308be177e297c08f5971646d81d3ec0c0R10): `UUID` およびその他の必要なクラスのインポートを追加しました。

### `NiteState` クラスの強化:

* [`src/main/kotlin/jp/trap/conqest/game/NiteState.kt`](diffhunk://#diff-eb8d41ac3369b30b4c74820944f4a02f8251ce74c313299666aefe5716ca5953R104-R106): `Nite` インスタンスの AI 状態を設定するために初期化ブロックを変更しました。

### `ListenerNiteControl` クラスの改善:

* [`src/main/kotlin/jp/trap/conqest/listeners/ListenerNiteControl.kt`](diffhunk://#diff-f2f9ffaa8f7ee8f176b56eccaf9a7f9b26ff72e1d4d55f7365deb93e44d3d505R45-R69): `Nite` のインタラクションと状態遷移を処理するために、`EntityDamageByEntityEvent` と `EntityDeathEvent` のイベント ハンドラーを追加しました。
* [`src/main/kotlin/jp/trap/conqest/listeners/ListenerNiteControl.kt`](diffhunk://#diff-f2f9ffaa8f7ee8f176b56eccaf9a7f9b26ff72e1d4d55f7365deb93e44d3d505R5-R33): 攻撃ターゲットの設定に `trySetTarget` を使用するように `onClickEntity` メソッドをリファクタリングしました。