### PR TITLE
fix bug #75

### DIFF
--- a/src/main/kotlin/jp/trap/conqest/game/Wallet.kt
+++ b/src/main/kotlin/jp/trap/conqest/game/Wallet.kt
@@ -19,14 +19,17 @@ object Wallet{
     fun onPlayerJoin(event: PlayerJoinEvent) {
         val player = event.player
         val uuid = player.uniqueId
-        if (scoreboardMap.containsKey(uuid)) {
-            setupScoreboard(player, scoreboardMap[uuid]!!)
+        scoreboardMap[uuid]?.let {
+            setupScoreboard(player, it)
             scoreboardMap.remove(uuid)
         }
     }
 
     fun onPlayerQuit(event: PlayerQuitEvent) {
-        scoreboardMap[event.player.uniqueId] = event.player.scoreboard.getObjective("wallet")?.getScore(OBJECTIVE_NAME)!!.score
+        event.player.scoreboard.getObjective("wallet")?.let {
+            scoreboardMap[event.player.uniqueId] = it.getScore(OBJECTIVE_NAME).score
+        }
+
     }
 
     fun setupScoreboard(player: Player, startCoin: Int) {


### PR DESCRIPTION
fix #75

このプルリクエストには、Kotlin の safe call 演算子と `let` 関数を使用してコードの可読性と安全性を向上させるための、`src/main/kotlin/jp/trap/conqest/game/Wallet.kt` の `Wallet` オブジェクトの変更が含まれています。最も重要な変更は次のとおりです:

コードの可読性と安全性の向上:

* `onPlayerJoin` メソッドを簡素化するために、`if` ステートメントを safe call 演算子と `let` 関数に置き換えました。
* 潜在的な `NullPointerException` を回避するために、`onPlayerQuit` メソッドで safe call 演算子と `let` 関数を使用しました。