### PR TITLE
ブロックのアイテムドロップをなくす

### DIFF
--- a/src/main/kotlin/jp/trap/conqest/game/Environment.kt
+++ b/src/main/kotlin/jp/trap/conqest/game/Environment.kt
@@ -19,6 +19,7 @@ object Environment {
             world.setGameRule(GameRule.KEEP_INVENTORY, true)
             world.setGameRule(GameRule.MOB_GRIEFING, false)
             world.setGameRule(GameRule.DO_MOB_LOOT, false)
+            world.setGameRule(GameRule.DO_TILE_DROPS, false)
             world.setGameRule(GameRule.DO_FIRE_TICK, false)
             world.setGameRule(GameRule.SHOW_DEATH_MESSAGES, false)
             world.difficulty = Difficulty.EASY


### PR DESCRIPTION
#35 に含めるのを忘れていたやつ。

フィールド生成時に種とかがドロップして、いちいち消すのめんどいので。
アドベンチャーモード想定なのでドロップする必要はないはず。