### PR TITLE
ゲーム終了時にリセットするように変更

### DIFF
--- a/src/main/kotlin/jp/trap/conqest/Main.kt
+++ b/src/main/kotlin/jp/trap/conqest/Main.kt
@@ -96,6 +96,7 @@ class Main : JavaPlugin() {
     override fun onDisable() {
         flowHandler.down()
         gameTimerManager.removeAllTimer()
+        gameManager.exit()
         logger.info("bye bye.")
     }
 }

--- a/src/main/kotlin/jp/trap/conqest/game/District.kt
+++ b/src/main/kotlin/jp/trap/conqest/game/District.kt
@@ -82,4 +82,12 @@ class District(
         val brokenTeam = if (nearEnemyNites.isEmpty()) Team.emptyTeam else nearEnemyNites.random().team
         setHp(min(maxHp, hp + hpChange), brokenTeam)
     }
+
+    fun reset() {
+        team = Team.emptyTeam
+    }
+
+    fun exit() {
+        coreArmorStand.remove()
+    }
 }

--- a/src/main/kotlin/jp/trap/conqest/game/Field.kt
+++ b/src/main/kotlin/jp/trap/conqest/game/Field.kt
@@ -13,9 +13,7 @@ class Field(val center: Location, val coreLocations: List<Location>, val size: P
     private val y_max: Int = (center.z + size.second / 2).toInt()
 
     constructor(
-        center: Location,
-        partition: Partition,
-        coreLocations: List<Location>
+        center: Location, partition: Partition, coreLocations: List<Location>
     ) : this(center, coreLocations, partition.fieldSize) {
         val districtCount = partition.districts.size
         val locations: MutableList<MutableSet<Pair<Int, Int>>> = MutableList(size = districtCount) { mutableSetOf() }
@@ -40,5 +38,13 @@ class Field(val center: Location, val coreLocations: List<Location>, val size: P
 
     fun getWorld(): World {
         return center.world
+    }
+
+    fun reset() {
+        districts.forEach { it.reset() }
+    }
+
+    fun exit() {
+        districts.forEach { it.exit() }
     }
 }

--- a/src/main/kotlin/jp/trap/conqest/game/Game.kt
+++ b/src/main/kotlin/jp/trap/conqest/game/Game.kt
@@ -60,8 +60,11 @@ class Game(val plugin: Plugin, val field: Field) {
     fun addNite(nite: Nite<*>, master: Player) {
         nites.computeIfAbsent(master.uniqueId) { ArrayList() }.add(nite)
     }
+
     fun removeNite(nite: Nite<*>) {
-        // TODO
+        nite.exit()
+        val key = nites.filter { it.value.contains(nite) }.keys.first()
+        nites[key]?.remove(nite)
     }
 
     fun judge() {
@@ -74,14 +77,19 @@ class Game(val plugin: Plugin, val field: Field) {
         mapView.centerX = 512
         mapView.centerZ = 512
         mapView.isUnlimitedTracking = true
-        for (renderer in mapView.renderers)
-            mapView.removeRenderer(renderer)
+        for (renderer in mapView.renderers) mapView.removeRenderer(renderer)
         mapView.addRenderer(GameMapRenderer(this))
         val mapItem = ItemStack(Material.FILLED_MAP)
         val meta: MapMeta = mapItem.itemMeta as MapMeta
         meta.mapId = mapView.id
         mapItem.itemMeta = meta
         return mapItem
+    }
+
+    fun reset() {
+        playersUUID.clear()
+        nites.flatMap { it.value }.forEach(::removeNite)
+        nites.clear()
     }
 
 }

--- a/src/main/kotlin/jp/trap/conqest/game/Game.kt
+++ b/src/main/kotlin/jp/trap/conqest/game/Game.kt
@@ -94,9 +94,9 @@ class Game(val plugin: Plugin, val field: Field) {
     }
 
     fun reset() {
-        playersUUID.clear()
         nites.flatMap { it.value }.forEach(::removeNite)
         nites.clear()
+        field.reset()
     }
 
 }

--- a/src/main/kotlin/jp/trap/conqest/game/GameManager.kt
+++ b/src/main/kotlin/jp/trap/conqest/game/GameManager.kt
@@ -35,4 +35,7 @@ class GameManager(val plugin: Plugin) {
         FieldTableUtil.saveField(field)
     }
 
+    fun exit() {
+        fields.forEach { it.exit() }
+    }
 }

--- a/src/main/kotlin/jp/trap/conqest/game/GameManager.kt
+++ b/src/main/kotlin/jp/trap/conqest/game/GameManager.kt
@@ -36,6 +36,7 @@ class GameManager(val plugin: Plugin) {
     }
 
     fun exit() {
+        games.forEach { it.reset() }
         fields.forEach { it.exit() }
     }
 }

--- a/src/main/kotlin/jp/trap/conqest/game/GameState.kt
+++ b/src/main/kotlin/jp/trap/conqest/game/GameState.kt
@@ -120,6 +120,7 @@ sealed class GameState(private val game: Game) {
                 game.getPlayers().forEach { player ->
                     player.teleport(game.lobby)
                 }
+                game.reset()
                 game.setState(BeforeGame(game))
             }, 20 * 5)
         }

--- a/src/main/kotlin/jp/trap/conqest/game/Nite.kt
+++ b/src/main/kotlin/jp/trap/conqest/game/Nite.kt
@@ -3,18 +3,17 @@ package jp.trap.conqest.game
 import net.kyori.adventure.text.Component
 import org.bukkit.Location
 import org.bukkit.attribute.Attribute
+import org.bukkit.damage.DamageSource
+import org.bukkit.damage.DamageType
 import org.bukkit.entity.*
 import org.bukkit.plugin.Plugin
 import org.bukkit.potion.PotionEffect
 import org.bukkit.potion.PotionEffectType
+import org.bukkit.scheduler.BukkitTask
 import java.util.*
 
 abstract class Nite<T>(
-    location: Location,
-    type: EntityType,
-    name: String,
-    val master: Player,
-    val plugin: Plugin
+    location: Location, type: EntityType, name: String, val master: Player, val plugin: Plugin
 ) where T : Entity, T : Mob {
     private var entity: T = location.world.spawnEntity(
         location, type, false
@@ -25,6 +24,7 @@ abstract class Nite<T>(
     protected open val attackSpeed = 1.0
     var state: NiteState = NiteState.FollowMaster(plugin, this)
     abstract val name: String
+    private val updateTask: BukkitTask
 
     init {
         entity.customName(Component.text(name))
@@ -33,7 +33,7 @@ abstract class Nite<T>(
             entity.registerAttribute(Attribute.ATTACK_DAMAGE)
             entity.getAttribute(Attribute.ATTACK_DAMAGE)?.baseValue = damage
         }
-        plugin.server.scheduler.runTaskTimer(plugin, Runnable { state.update() }, 0, 1)
+        updateTask = plugin.server.scheduler.runTaskTimer(plugin, Runnable { state.update() }, 0, 1)
     }
 
 
@@ -83,6 +83,13 @@ abstract class Nite<T>(
 
     fun setAi(value: Boolean) {
         entity.setAI(value)
+    }
+
+    fun exit() {
+        // kill entity
+        entity.damage(Double.POSITIVE_INFINITY, DamageSource.builder(DamageType.GENERIC_KILL).build())
+        state.exit()
+        updateTask.cancel()
     }
 
 }

--- a/src/main/kotlin/jp/trap/conqest/game/NiteState.kt
+++ b/src/main/kotlin/jp/trap/conqest/game/NiteState.kt
@@ -3,15 +3,11 @@ package jp.trap.conqest.game
 import org.bukkit.block.Block
 import org.bukkit.entity.LivingEntity
 import org.bukkit.plugin.Plugin
+import org.bukkit.scheduler.BukkitRunnable
+import org.bukkit.scheduler.BukkitTask
 
 enum class NiteStates {
-    FOLLOW_MASTER,
-    STATION_DISTRICT,
-    GUARD_DISTRICT,
-    ATTACK,
-    ATTACK_CORE,
-    EARN_COIN,
-    DEAD,
+    FOLLOW_MASTER, STATION_DISTRICT, GUARD_DISTRICT, ATTACK, ATTACK_CORE, EARN_COIN, DEAD,
 }
 
 sealed class NiteState(val plugin: Plugin, val nite: Nite<*>) {
@@ -20,16 +16,18 @@ sealed class NiteState(val plugin: Plugin, val nite: Nite<*>) {
 
     open fun update() {}
 
+    abstract fun exit()
+
     class FollowMaster(plugin: Plugin, nite: Nite<*>, override val type: NiteStates = NiteStates.FOLLOW_MASTER) :
         NiteState(plugin, nite) {
         private val nearDistance = 5
 
         override fun update() {
-            if (nite.distance(nite.master) >= nearDistance)
-                nite.moveTo(nite.master.location)
-            else
-                nite.moveStop()
+            if (nite.distance(nite.master) >= nearDistance) nite.moveTo(nite.master.location)
+            else nite.moveStop()
         }
+
+        override fun exit() {}
     }
 
     class StationDistrict(plugin: Plugin, nite: Nite<*>, override val type: NiteStates = NiteStates.STATION_DISTRICT) :
@@ -38,6 +36,8 @@ sealed class NiteState(val plugin: Plugin, val nite: Nite<*>) {
         override fun update() {
             // TODO 領土内を歩き回る
         }
+
+        override fun exit() {}
     }
 
     class GuardDistrict(plugin: Plugin, nite: Nite<*>, override val type: NiteStates = NiteStates.GUARD_DISTRICT) :
@@ -45,6 +45,8 @@ sealed class NiteState(val plugin: Plugin, val nite: Nite<*>) {
         override fun update() {
             // TODO 敵が領土内にいる場合、敵を攻撃 / いなくなったらStationDistrictへ
         }
+
+        override fun exit() {}
     }
 
     class Attack(
@@ -52,8 +54,7 @@ sealed class NiteState(val plugin: Plugin, val nite: Nite<*>) {
         nite: Nite<*>,
         private val target: LivingEntity,
         override val type: NiteStates = NiteStates.ATTACK
-    ) :
-        NiteState(plugin, nite) {
+    ) : NiteState(plugin, nite) {
         override fun update() {
             if (target.isDead) {
                 nite.state = FollowMaster(plugin, nite)
@@ -61,15 +62,13 @@ sealed class NiteState(val plugin: Plugin, val nite: Nite<*>) {
             nite.moveTo(target.location)
             nite.tryAttack(target)
         }
+
+        override fun exit() {}
     }
 
     class AttackCore(
-        plugin: Plugin,
-        nite: Nite<*>,
-        private val target: Block,
-        override val type: NiteStates = NiteStates.ATTACK_CORE
-    ) :
-        NiteState(plugin, nite) {
+        plugin: Plugin, nite: Nite<*>, private val target: Block, override val type: NiteStates = NiteStates.ATTACK_CORE
+    ) : NiteState(plugin, nite) {
         override fun update() {
             if (target.isEmpty) {
                 nite.state = FollowMaster(plugin, nite)
@@ -77,38 +76,50 @@ sealed class NiteState(val plugin: Plugin, val nite: Nite<*>) {
             nite.moveTo(target.location)
             // TODO ブロック破壊
         }
+
+        override fun exit() {}
     }
 
     class EarnCoin(plugin: Plugin, nite: Nite<*>, override val type: NiteStates = NiteStates.EARN_COIN) :
         NiteState(plugin, nite) {
         private val respawnDelay: Long = 30
+        private val task: BukkitTask
 
         init {
             nite.setVisible(false)
             nite.master.sendMessage(nite.name + "はコイン収集を開始しました")
-            plugin.server.scheduler.runTaskLater(plugin, Runnable {
+            task = plugin.server.scheduler.runTaskLater(plugin, Runnable {
                 nite.setVisible(true)
                 nite.teleport(nite.master.location)
                 nite.master.sendMessage(nite.name + "が復活しました")
                 nite.state = FollowMaster(plugin, nite)
             }, respawnDelay * 20)
         }
+
+        override fun exit() {
+            task.cancel()
+        }
     }
 
     class Dead(plugin: Plugin, nite: Nite<*>, override val type: NiteStates = NiteStates.DEAD) :
         NiteState(plugin, nite) {
         private val respawnDelay: Long = 30
+        private val task: BukkitTask
 
         init {
             nite.setVisible(false)
             nite.setAi(false)
-            plugin.server.scheduler.runTaskLater(plugin, Runnable {
+            task = plugin.server.scheduler.runTaskLater(plugin, Runnable {
                 nite.setAi(true)
                 nite.setVisible(true)
                 nite.teleport(nite.master.location)
                 nite.master.sendMessage(nite.name + "が復活しました")
                 nite.state = FollowMaster(plugin, nite)
             }, respawnDelay * 20)
+        }
+
+        override fun exit() {
+            task.cancel()
         }
     }
 


### PR DESCRIPTION
fix #48 

ゲーム終了時にちゃんと状況をリセットするようにしました

---

このプル リクエストでは、ゲーム ロジックにいくつかの変更が導入され、特に `Nite` エンティティとその状態の管理に重点が置かれています。最も重要な変更には、`removeNite` 関数の実装、`Game` クラスへの `reset` 関数の追加、`Nite` とその状態の `exit` メソッドの導入が含まれます。

### ゲーム クラスの強化:
* `Nite` エンティティのゲームからの削除を適切に処理するために `removeNite` 関数を実装しました。これには、`Nite` で `exit` メソッドを呼び出し、`nites` コレクションから削除することが含まれます。
* すべてのプレイヤーと `Nite` エンティティをクリアして、ゲームをクリーンな状態にするために `Game` クラスに `reset` 関数を追加しました。

### ゲーム状態の管理:
* `BeforeGame` 状態に移行するときに `Game` インスタンスで `reset` 関数を呼び出すように `GameState` クラスを変更し、ゲームが適切にリセットされるようにしました。

### Nite エンティティの機能強化:
* `Nite` クラスに `exit` メソッドを追加し、スケジュールされたタスクの停止やゲームからのエンティティの削除など、`Nite` エンティティのクリーンアップを処理しました。
* `Nite` コンストラクターを更新し、`updateTask` 変数を初期化しました。この変数は、`Nite` エンティティの定期的な更新を管理するために使用されます。

### Nite 状態の機能強化:
* スケジュールされたタスクなどの状態固有のリソースが適切にクリーンアップされるように、すべての `NiteState` サブクラスに `exit` メソッドを導入しました。