### PR TITLE
Feat/niteenchantmentitem

### DIFF
--- a/src/main/kotlin/jp/trap/conqest/game/Nite.kt
+++ b/src/main/kotlin/jp/trap/conqest/game/Nite.kt
@@ -16,17 +16,7 @@ abstract class Nite<T>(
     val master: Player,
     val plugin: Plugin
 ) where T : Entity, T : Mob {
-    companion object {
-        private val registeredEntities = mutableSetOf<Entity>()
-        fun isNiteEntity(entity: Entity): Boolean {
-            return registeredEntities.contains(entity)
-        }
 
-        fun removeNite(entity: Entity) {
-            registeredEntities.remove(entity)
-        }
-    }
-    
     private var entity: T = location.world.spawnEntity(
         location, type, false
     ) as T
@@ -40,7 +30,6 @@ abstract class Nite<T>(
     init {
         entity.customName(Component.text(name))
         entity.addPotionEffect(PotionEffect(PotionEffectType.GLOWING, Int.MAX_VALUE, 1))
-        registeredEntities.add(entity)
         if (entity.getAttribute(Attribute.ATTACK_DAMAGE) == null) {
             entity.registerAttribute(Attribute.ATTACK_DAMAGE)
             entity.getAttribute(Attribute.ATTACK_DAMAGE)?.baseValue = damage

--- a/src/main/kotlin/jp/trap/conqest/game/Nite.kt
+++ b/src/main/kotlin/jp/trap/conqest/game/Nite.kt
@@ -10,6 +10,18 @@ import org.bukkit.potion.PotionEffectType
 
 abstract class Nite<T>(location: Location, type: EntityType, name: String, val master: Player, val plugin: Plugin)
         where T : Entity, T : Mob {
+
+    companion object {
+        private val registeredEntities = mutableSetOf<Entity>()
+        fun isNiteEntity(entity: Entity): Boolean {
+            return registeredEntities.contains(entity)
+        }
+
+        fun removeNite(entity: Entity) {
+            registeredEntities.remove(entity)
+        }
+    }
+
     private var entity: T = location.world.spawnEntity(
         location, type, false
     ) as T
@@ -23,6 +35,7 @@ abstract class Nite<T>(location: Location, type: EntityType, name: String, val m
     init {
         entity.customName(Component.text(name))
         entity.addPotionEffect(PotionEffect(PotionEffectType.GLOWING, Int.MAX_VALUE, 1))
+        registeredEntities.add(entity)
         if (entity.getAttribute(Attribute.ATTACK_DAMAGE) == null) {
             entity.registerAttribute(Attribute.ATTACK_DAMAGE)
             entity.getAttribute(Attribute.ATTACK_DAMAGE)?.baseValue = damage

--- a/src/main/kotlin/jp/trap/conqest/game/item/NiteEnchantmentItem.kt
+++ b/src/main/kotlin/jp/trap/conqest/game/item/NiteEnchantmentItem.kt
@@ -1,30 +1,18 @@
 package jp.trap.conqest.game.item
 
-import jp.trap.conqest.game.Nite
 import org.bukkit.ChatColor
 import org.bukkit.Material
-import org.bukkit.entity.Entity
-import org.bukkit.entity.Player
-import org.bukkit.event.player.PlayerInteractEntityEvent
 import org.bukkit.inventory.ItemStack
 
-object NiteEnchantmentItem : UsableItem{
-    override val item: ItemStack = run{
+object NiteEnchantmentItem {
+    val item: ItemStack = run {
         val niteEnchantmentItem = ItemStack(Material.AMETHYST_SHARD)
         val meta = niteEnchantmentItem.itemMeta
-        if(meta != null){
+        if (meta != null) {
             meta.setDisplayName("${ChatColor.AQUA}ナイト強化アイテム")
             niteEnchantmentItem.setItemMeta(meta)
         }
         niteEnchantmentItem
     }
-    override val onUsed = { event: PlayerInteractEntityEvent->
-        val player: Player = event.player
-        val clickedEntity: Entity = event.rightClicked
-        val itemInHand: ItemStack = player.inventory.itemInMainHand
-        if(true/*clickedEntity == Nite*/){
-            itemInHand.amount--
-            player.sendMessage("ナイトを強化しました")
-        }
-    }
+
 }

--- a/src/main/kotlin/jp/trap/conqest/game/item/NiteEnchantmentItem.kt
+++ b/src/main/kotlin/jp/trap/conqest/game/item/NiteEnchantmentItem.kt
@@ -1,0 +1,30 @@
+package jp.trap.conqest.game.item
+
+import jp.trap.conqest.game.Nite
+import org.bukkit.ChatColor
+import org.bukkit.Material
+import org.bukkit.entity.Entity
+import org.bukkit.entity.Player
+import org.bukkit.event.player.PlayerInteractEntityEvent
+import org.bukkit.inventory.ItemStack
+
+object NiteEnchantmentItem : UsableItem{
+    override val item: ItemStack = run{
+        val niteEnchantmentItem = ItemStack(Material.AMETHYST_SHARD)
+        val meta = niteEnchantmentItem.itemMeta
+        if(meta != null){
+            meta.setDisplayName("${ChatColor.AQUA}ナイト強化アイテム")
+            niteEnchantmentItem.setItemMeta(meta)
+        }
+        niteEnchantmentItem
+    }
+    override val onUsed = { event: PlayerInteractEntityEvent->
+        val player: Player = event.player
+        val clickedEntity: Entity = event.rightClicked
+        val itemInHand: ItemStack = player.inventory.itemInMainHand
+        if(true/*clickedEntity == Nite*/){
+            itemInHand.amount--
+            player.sendMessage("ナイトを強化しました")
+        }
+    }
+}

--- a/src/main/kotlin/jp/trap/conqest/game/item/ShopBook.kt
+++ b/src/main/kotlin/jp/trap/conqest/game/item/ShopBook.kt
@@ -41,6 +41,7 @@ object ShopBook : UsableItem {
         SellingItem(ChanceCard.item, 100, null),
         SellingItem(ItemStack(Material.IRON_SWORD), 1000, null),
         SellingItem(ItemStack(Material.WOODEN_SWORD), 1, null),
+        SellingItem(NiteEnchantmentItem.item, 30, null),
         SellingItem(ShopItemNite.itemNormalNite, 10) { player ->
             Main.instance.gameManager.getGame(player)
                 ?.addNite(NormalNite(player.location, "NormalNite", player, Main.instance), player)

--- a/src/main/kotlin/jp/trap/conqest/listeners/ListenerNiteEnchantmentItem.kt
+++ b/src/main/kotlin/jp/trap/conqest/listeners/ListenerNiteEnchantmentItem.kt
@@ -1,6 +1,9 @@
 package jp.trap.conqest.listeners
 
+import jp.trap.conqest.Main
+import jp.trap.conqest.game.GameManager
 import jp.trap.conqest.game.Nite
+import jp.trap.conqest.game.item.NiteEnchantmentItem
 import org.bukkit.ChatColor
 import org.bukkit.Material
 import org.bukkit.entity.Entity
@@ -11,9 +14,9 @@ import org.bukkit.inventory.ItemStack
 import java.util.UUID
 
 class ListenerNiteEnchantmentItem : Listener {
+    private val gameManager = GameManager(Main.instance)
     private val cooldowns: MutableMap<UUID, Long> = mutableMapOf()
     private val cooldownTime: Long = 10L
-
     @EventHandler
     fun onPlayerUse(event: PlayerInteractEntityEvent) {
         val player = event.player
@@ -26,10 +29,11 @@ class ListenerNiteEnchantmentItem : Listener {
                 return
             }
         }
-        val itemMeta = itemInHand.itemMeta
-        if (itemMeta != null && itemMeta.hasDisplayName() && itemMeta.displayName == "${ChatColor.AQUA}ナイト強化アイテム") {
+
+        if (itemInHand.isSimilar(NiteEnchantmentItem.item)) {
             val clickedEntity: Entity = event.rightClicked
-            if (Nite.isNiteEntity(clickedEntity)) {
+            val nite = gameManager.getGames().flatMap { game -> game.getNites() }.singleOrNull { nite -> nite.getUniqueId() == clickedEntity.uniqueId }
+            if (nite != null) {
                 itemInHand.amount--
                 cooldowns[player.uniqueId] = currentTime
                 player.sendMessage("${ChatColor.LIGHT_PURPLE}ナイトを強化しました!")

--- a/src/main/kotlin/jp/trap/conqest/listeners/ListenerNiteEnchantmentItem.kt
+++ b/src/main/kotlin/jp/trap/conqest/listeners/ListenerNiteEnchantmentItem.kt
@@ -1,0 +1,40 @@
+package jp.trap.conqest.listeners
+
+import jp.trap.conqest.game.Nite
+import org.bukkit.ChatColor
+import org.bukkit.Material
+import org.bukkit.entity.Entity
+import org.bukkit.event.EventHandler
+import org.bukkit.event.Listener
+import org.bukkit.event.player.PlayerInteractEntityEvent
+import org.bukkit.inventory.ItemStack
+import java.util.UUID
+
+class ListenerNiteEnchantmentItem : Listener {
+    private val cooldowns: MutableMap<UUID, Long> = mutableMapOf()
+    private val cooldownTime: Long = 10L
+
+    @EventHandler
+    fun onPlayerUse(event: PlayerInteractEntityEvent) {
+        val player = event.player
+        val itemInHand: ItemStack = player.inventory.itemInMainHand
+        if (itemInHand.type == Material.AIR || itemInHand.type != Material.AMETHYST_SHARD) return
+        val currentTime = System.currentTimeMillis()
+        if (cooldowns.containsKey(player.uniqueId)) {
+            val lastUsed = cooldowns[player.uniqueId]!!
+            if (currentTime - lastUsed < cooldownTime) {
+                return
+            }
+        }
+        val itemMeta = itemInHand.itemMeta
+        if (itemMeta != null && itemMeta.hasDisplayName() && itemMeta.displayName == "${ChatColor.AQUA}ナイト強化アイテム") {
+            val clickedEntity: Entity = event.rightClicked
+            if (Nite.isNiteEntity(clickedEntity)) {
+                itemInHand.amount--
+                cooldowns[player.uniqueId] = currentTime
+                player.sendMessage("${ChatColor.LIGHT_PURPLE}ナイトを強化しました!")
+            }
+        }
+        return
+    }
+}

--- a/src/main/kotlin/jp/trap/conqest/listeners/ListenerNiteEnchantmentItem.kt
+++ b/src/main/kotlin/jp/trap/conqest/listeners/ListenerNiteEnchantmentItem.kt
@@ -13,8 +13,8 @@ import org.bukkit.event.player.PlayerInteractEntityEvent
 import org.bukkit.inventory.ItemStack
 import java.util.UUID
 
-class ListenerNiteEnchantmentItem : Listener {
-    private val gameManager = GameManager(Main.instance)
+class ListenerNiteEnchantmentItem(plugin: Main) : Listener {
+    private val gameManager = GameManager(plugin)
     private val cooldowns: MutableMap<UUID, Long> = mutableMapOf()
     private val cooldownTime: Long = 10L
     @EventHandler
@@ -32,7 +32,7 @@ class ListenerNiteEnchantmentItem : Listener {
 
         if (itemInHand.isSimilar(NiteEnchantmentItem.item)) {
             val clickedEntity: Entity = event.rightClicked
-            val nite = gameManager.getGames().flatMap { game -> game.getNites() }.singleOrNull { nite -> nite.getUniqueId() == clickedEntity.uniqueId }
+            val nite = gameManager.getGames().flatMap { game -> game.getNites() }.firstOrNull { nite -> nite.getUniqueId() == clickedEntity.uniqueId }
             if (nite != null) {
                 itemInHand.amount--
                 cooldowns[player.uniqueId] = currentTime

--- a/src/main/kotlin/jp/trap/conqest/listeners/ListenerNiteEnchantmentItem.kt
+++ b/src/main/kotlin/jp/trap/conqest/listeners/ListenerNiteEnchantmentItem.kt
@@ -14,7 +14,7 @@ import org.bukkit.inventory.ItemStack
 import java.util.UUID
 
 class ListenerNiteEnchantmentItem(plugin: Main) : Listener {
-    private val gameManager = GameManager(plugin)
+    private val gameManager = plugin.gameManager
     private val cooldowns: MutableMap<UUID, Long> = mutableMapOf()
     private val cooldownTime: Long = 10L
     @EventHandler

--- a/src/main/kotlin/jp/trap/conqest/listeners/Listeners.kt
+++ b/src/main/kotlin/jp/trap/conqest/listeners/Listeners.kt
@@ -17,7 +17,7 @@ class Listeners(
         registerListener(ListenerNiteControl(plugin.gameManager))
         registerListener(ListenerGameTimer(plugin))
         registerListener(ListenerWallet())
-        registerListener(ListenerNiteEnchantmentItem())
+        registerListener(ListenerNiteEnchantmentItem(plugin))
         registerListener(ListenerDistrictCore(plugin.gameManager))
         return Result.success(Unit)
     }

--- a/src/main/kotlin/jp/trap/conqest/listeners/Listeners.kt
+++ b/src/main/kotlin/jp/trap/conqest/listeners/Listeners.kt
@@ -17,6 +17,7 @@ class Listeners(
         registerListener(ListenerNiteControl(plugin.gameManager))
         registerListener(ListenerGameTimer(plugin))
         registerListener(ListenerWallet())
+        registerListener(ListenerNiteEnchantmentItem())
         return Result.success(Unit)
     }
 }


### PR DESCRIPTION
#24 ナイトに使用できるアイテムを実装
ナイトかどうかは、召喚したナイトをセットに入れておいて入っているかで判定
1クリックで2回くらい使われてしまわないようクールタイム(0.01秒)を追加
ナイトがいなくなる時にはNite.remove(ooo)を