### PR TITLE
Niteがコアを破壊できるようになった

### DIFF
--- a/src/main/kotlin/jp/trap/conqest/game/District.kt
+++ b/src/main/kotlin/jp/trap/conqest/game/District.kt
@@ -1,13 +1,42 @@
 package jp.trap.conqest.game
 
 import org.bukkit.Location
-import org.bukkit.scoreboard.Team
+import kotlin.math.min
+import kotlin.math.roundToInt
 
-class District(val id: Int, private val locations: Set<Pair<Int, Int>>, private val coreLocation: Location, private var team: Team? = null) {
+class District(
+    val id: Int,
+    private val locations: Set<Pair<Int, Int>>,
+    private val coreLocation: Location,
+    private var team: Team? = null
+) {
+    val savingNite: Nite<*>? = null // TODO
+
+    private val maxHp: Int = 100
+    private var hp: Int = maxHp
+    private val hpRegenRate: Int = 1
+
     fun setTeam(team: Team) {
         this.team = team
     }
+
     fun contains(location: Pair<Int, Int>): Boolean {
         return location in locations
+    }
+
+    private fun nearCore(location: Location): Boolean {
+        val nearDistance = 3.0
+        return coreLocation.distance(location) <= nearDistance
+    }
+
+    fun updateHp(game: Game) {
+        val nearEnemyNites = game.getNites().filter { nearCore(it.getLocation()) && it.getTeam() != team }
+        if (nearEnemyNites.isEmpty()) {
+            hp += hpRegenRate
+        } else {
+            val arrackRate: Double = nearEnemyNites.sumOf { nite -> nite.blockBreakSpeed }
+            hp -= arrackRate.roundToInt()
+        }
+        hp = min(maxHp, hp)
     }
 }

--- a/src/main/kotlin/jp/trap/conqest/game/District.kt
+++ b/src/main/kotlin/jp/trap/conqest/game/District.kt
@@ -50,10 +50,10 @@ class District(
         return location in locations
     }
 
-    fun changeHP(hp: Double): Boolean {
+    fun changeHP(hp: Int): Boolean {
         if (coreBreakable.not()) return false
         this.hp = hp
-        coreArmorStand.customName(Component.text(hp.roundToInt().toString() + "%").color(NamedTextColor.WHITE))
+        coreArmorStand.customName(Component.text("$hp%").color(NamedTextColor.WHITE))
         return true
     }
 

--- a/src/main/kotlin/jp/trap/conqest/game/Environment.kt
+++ b/src/main/kotlin/jp/trap/conqest/game/Environment.kt
@@ -1,5 +1,6 @@
 package jp.trap.conqest.game
 
+import jp.trap.conqest.Main
 import org.bukkit.Bukkit
 import org.bukkit.Difficulty
 import org.bukkit.GameRule
@@ -39,6 +40,11 @@ object Environment {
                 if (entity is LivingEntity) {
                     entity.addPotionEffect(PotionEffect(PotionEffectType.FIRE_RESISTANCE, 2, 0, true, false, false))
                 }
+            }
+        }
+        Main.instance.gameManager.getGames().forEach { game ->
+            game.field.districts.forEach { district ->
+                district.updateHp(game)
             }
         }
     }

--- a/src/main/kotlin/jp/trap/conqest/game/Field.kt
+++ b/src/main/kotlin/jp/trap/conqest/game/Field.kt
@@ -9,7 +9,7 @@ class Field(
     partition: Partition,
     private val coreLocations: List<Location>
 ) {
-    private val districts: List<District>
+    val districts: List<District>
     private val x_min: Int = (center.x - partition.fieldSize.first / 2).toInt()
     private val x_max: Int = (center.x + partition.fieldSize.second / 2).toInt()
     private val y_min: Int = (center.z - partition.fieldSize.first / 2).toInt()
@@ -36,6 +36,6 @@ class Field(
     }
 
     fun getWorld(): World {
-        return center.world;
+        return center.world
     }
 }

--- a/src/main/kotlin/jp/trap/conqest/game/Game.kt
+++ b/src/main/kotlin/jp/trap/conqest/game/Game.kt
@@ -58,6 +58,7 @@ class Game(val plugin: Plugin, val field: Field) {
     }
 
     fun addNite(nite: Nite<*>, master: Player) {
+        nite.team = getTeam(master) ?: Team.emptyTeam
         nites.computeIfAbsent(master.uniqueId) { ArrayList() }.add(nite)
     }
 

--- a/src/main/kotlin/jp/trap/conqest/game/GameState.kt
+++ b/src/main/kotlin/jp/trap/conqest/game/GameState.kt
@@ -76,7 +76,7 @@ sealed class GameState(private val game: Game) {
 
     class Playing(private val game: Game) : GameState(game) {
         override val type: GameStates = GameStates.PLAYING
-        private val gameTime: Long = 20 // 5 * 60
+        private val gameTime: Long = 5 * 60
         private val initialCoin: Int = 100
 
         init {

--- a/src/main/kotlin/jp/trap/conqest/game/Nite.kt
+++ b/src/main/kotlin/jp/trap/conqest/game/Nite.kt
@@ -22,6 +22,7 @@ abstract class Nite<T>(
     open val blockBreakSpeed: Double = 1.0
     var state: NiteState = NiteState.FollowMaster(plugin, this)
     abstract val name: String
+    var team: Team = Team.emptyTeam
 
     init {
         entity.customName(Component.text(name))
@@ -81,9 +82,4 @@ abstract class Nite<T>(
     fun setAi(value: Boolean) {
         entity.setAI(value)
     }
-
-    fun getTeam(): Team {
-        TODO()
-    }
-
 }

--- a/src/main/kotlin/jp/trap/conqest/game/Nite.kt
+++ b/src/main/kotlin/jp/trap/conqest/game/Nite.kt
@@ -10,11 +10,7 @@ import org.bukkit.potion.PotionEffectType
 import java.util.*
 
 abstract class Nite<T>(
-    location: Location,
-    type: EntityType,
-    name: String,
-    val master: Player,
-    val plugin: Plugin
+    location: Location, type: EntityType, name: String, val master: Player, val plugin: Plugin
 ) where T : Entity, T : Mob {
     private var entity: T = location.world.spawnEntity(
         location, type, false
@@ -23,6 +19,7 @@ abstract class Nite<T>(
     protected open val damage = 1.0
     protected open val handLength = 3.0
     protected open val attackSpeed = 1.0
+    open val blockBreakSpeed: Double = 1.0
     var state: NiteState = NiteState.FollowMaster(plugin, this)
     abstract val name: String
 
@@ -83,6 +80,10 @@ abstract class Nite<T>(
 
     fun setAi(value: Boolean) {
         entity.setAI(value)
+    }
+
+    fun getTeam(): Team {
+        TODO()
     }
 
 }

--- a/src/main/kotlin/jp/trap/conqest/listeners/ListenerDistrictCore.kt
+++ b/src/main/kotlin/jp/trap/conqest/listeners/ListenerDistrictCore.kt
@@ -28,6 +28,6 @@ class ListenerDistrictCore(private val gameManager: GameManager) : Listener {
         val game = gameManager.getGame(player) ?: return
         val districts = game.field.districts
         val district = districts.firstOrNull { district -> district.coreLocation.block == event.block.location.block }
-        district?.changeHP(100 - event.progress.toDouble() * 100)
+        district?.changeHP((100 - event.progress.toDouble() * 100).toInt())
     }
 }

--- a/src/main/kotlin/jp/trap/conqest/listeners/ListenerDistrictCore.kt
+++ b/src/main/kotlin/jp/trap/conqest/listeners/ListenerDistrictCore.kt
@@ -17,7 +17,7 @@ class ListenerDistrictCore(private val gameManager: GameManager) : Listener {
         val team = game.getTeam(player)
         if (district != null && team != null) {
             event.isCancelled = true
-            district.setTeam(team)
+            district.setHp(0, team)
         }
     }
 
@@ -28,6 +28,6 @@ class ListenerDistrictCore(private val gameManager: GameManager) : Listener {
         val game = gameManager.getGame(player) ?: return
         val districts = game.field.districts
         val district = districts.firstOrNull { district -> district.coreLocation.block == event.block.location.block }
-        district?.changeHP((100 - event.progress.toDouble() * 100).toInt())
+        district?.setHp((100 - event.progress.toDouble() * 100).toInt(), game.getTeam(player))
     }
 }


### PR DESCRIPTION
単純に近づきます
1tickごとに、HPが1%(仮)増えます
1tickごとに、周囲の(コアと異なるチームの)Niteの「破壊力」の総量(%)だけHPが減ります
値は雑です

---

このプル リクエストには、特に `District` クラスと関連機能に重点を置いた、ゲーム メカニクスを強化するための `jp.trap.conqest.game` パッケージの変更が含まれています。最も重要な変更には、地区の HP 再生と攻撃メカニクスの導入、`Nite` エンティティへのチーム属性の追加、およびこれらの新機能を組み込むためのゲーム更新ロジックの変更が含まれます。

`District` メカニクスの強化:

* [`src/main/kotlin/jp/trap/conqest/game/District.kt`](diffhunk://#diff-cc97a5417bb9369741ab84f093a155defa5d6147507335af1ddeda1f04056541L20-R25): HP 再生と攻撃メカニクスを処理するために、`maxHp`、`hpRegenRate`、および `updateHp` メソッドを導入しました。`setHp` メソッドは、地区の HP を更新し、HP がゼロになったときにチームの変更を処理するようになりました。 [[1]](diffhunk://#diff-cc97a5417bb9369741ab84f093a155defa5d6147507335af1ddeda1f04056541L20-R25) [[2]](diffhunk://#diff-cc97a5417bb9369741ab84f093a155defa5d6147507335af1ddeda1f04056541L49-R83) [[3]](diffhunk://#diff-cc97a5417bb9369741ab84f093a155defa5d6147507335af1ddeda1f04056541L33-R44)

ゲーム更新ロジックとの統合:

* [`src/main/kotlin/jp/trap/conqest/game/Environment.kt`](diffhunk://#diff-1c9fe174582f55a6f238fdb8a6a34cab754f893c2112bcb2199c95904290db29R46-R50): ゲーム更新ループを変更し、各地区で `updateHp` を呼び出すようにしました。これにより、HP 再生と攻撃メカニズムが毎ティックで処理されるようになりました。

`Nite` エンティティのチーム属性:

* [`src/main/kotlin/jp/trap/conqest/game/Nite.kt`](diffhunk://#diff-5eb2a924c58ea68fa77624864bd57a2308be177e297c08f5971646d81d3ec0c0R22-R25): `Nite` エンティティに、関連するチームを追跡するための `team` 属性と、地区 HP の変更に影響を与える `blockBreakSpeed` 属性を追加しました。 [[1]](diffhunk://#diff-5eb2a924c58ea68fa77624864bd57a2308be177e297c08f5971646d81d3ec0c0R22-R25) [[2]](diffhunk://#diff-5eb2a924c58ea68fa77624864bd57a2308be177e297c08f5971646d81d3ec0c0L13-R13)

追加のマイナーな改善:

* [`src/main/kotlin/jp/trap/conqest/game/Game.kt`](diffhunk://#diff-b6c1bcb3b7dd61aa4f038ec22cb244dc5c4f7f6c73eac26e9e1276558f65162dR61): ゲームに追加されたときに、`Nite` エンティティが正しいチームに割り当てられるようにしました。
* [`src/main/kotlin/jp/trap/conqest/game/GameState.kt`](diffhunk://#diff-d1833ad920f9eb9456000b62f7cd97f8edcd6e29b32d680c0fccd9758bc9f112L79-R79): `Playing` 状態のゲーム時間を意図した期間に修正しました。

これらの変更により、地区の動的な HP 管理が追加され、ゲーム エンティティの一貫したチーム関連付けが確保され、ゲームプレイが総合的に強化されます。