### PR TITLE
ビーコンとマップの色を領土と同期

### DIFF
--- a/src/main/kotlin/jp/trap/conqest/game/District.kt
+++ b/src/main/kotlin/jp/trap/conqest/game/District.kt
@@ -15,13 +15,14 @@ class District(
     val coreLocation: Location,
     private var team: Team = Team.emptyTeam
 ) {
-    private val coreBlock: Block = coreLocation.block
+    //private val coreBlock: Block = coreLocation.block
+    private val coreGlass: Block = coreLocation.clone().add(0.0, 1.0, 0.0).block
     private val coreArmorStand: ArmorStand
     private var hp: Double = 100.0
     private var coreBreakable: Boolean = true
 
     init {
-        coreBlock.type = team.color.getConcreteMaterial()
+        coreGlass.type = team.color.getGlassMaterial()
         coreArmorStand = coreLocation.world.spawnEntity(
             coreLocation.clone().add(Vector(0.5, -1.0, 0.5)), EntityType.ARMOR_STAND
         ) as ArmorStand
@@ -38,7 +39,7 @@ class District(
     }
 
     fun setTeam(team: Team) {
-        coreBlock.type = team.color.getConcreteMaterial()
+        coreGlass.type = team.color.getGlassMaterial()
         this.team = team
     }
 
@@ -55,7 +56,7 @@ class District(
 
     fun onBreak(attackerTeam: Team): Boolean {
         if (coreBreakable.not()) return false
-        coreBlock.type = attackerTeam.color.getConcreteMaterial()
+        coreGlass.type = attackerTeam.color.getGlassMaterial()
         return true
     }
 

--- a/src/main/kotlin/jp/trap/conqest/game/Field.kt
+++ b/src/main/kotlin/jp/trap/conqest/game/Field.kt
@@ -5,11 +5,10 @@ import org.bukkit.Location
 import org.bukkit.World
 
 class Field(
-    val center: Location,
-    partition: Partition,
-    private val coreLocations: List<Location>
+    val center: Location, partition: Partition, private val coreLocations: List<Location>
 ) {
     val districts: List<District>
+    val graph: List<Set<Int>>
     private val x_min: Int = (center.x - partition.fieldSize.first / 2).toInt()
     private val x_max: Int = (center.x + partition.fieldSize.second / 2).toInt()
     private val y_min: Int = (center.z - partition.fieldSize.first / 2).toInt()
@@ -23,6 +22,7 @@ class Field(
             locations[idx].add(x to y)
         }
         districts = (0 until districtCount).map { i -> District(i, locations[i], coreLocations[i]) }
+        graph = partition.graph
     }
 
     val size: Pair<Int, Int> = partition.fieldSize
@@ -36,6 +36,6 @@ class Field(
     }
 
     fun getWorld(): World {
-        return center.world;
+        return center.world
     }
 }

--- a/src/main/kotlin/jp/trap/conqest/game/FieldGenerator.kt
+++ b/src/main/kotlin/jp/trap/conqest/game/FieldGenerator.kt
@@ -20,6 +20,7 @@ class FieldGenerator(
         val wall = Material.BEDROCK
         val core = Material.BEACON
         val coreBase = Material.IRON_BLOCK
+        val coreBeam = Material.GLASS_PANE
         val fence = Material.STONE_BRICK_WALL
         val road = Material.DIRT_PATH
     }
@@ -108,6 +109,10 @@ class FieldGenerator(
                     Materials.coreBase.createBlockData()
             }
             blockChanges[coreLoc] = Materials.core.createBlockData()
+            for (y in 1..16) {
+                if (coreLoc.blockY + y > target.world.maxHeight) break
+                blockChanges[coreLoc.clone().add(0.0, y.toDouble(), 0.0)] = Materials.coreBeam.createBlockData()
+            }
             coreLocationSet.add(coreLoc)
         }
         coreLocations.clear()

--- a/src/main/kotlin/jp/trap/conqest/game/GameMapRenderer.kt
+++ b/src/main/kotlin/jp/trap/conqest/game/GameMapRenderer.kt
@@ -8,7 +8,6 @@ import org.bukkit.map.MapView
 import org.bukkit.util.Vector
 import java.awt.image.BufferedImage
 import kotlin.math.atan2
-import kotlin.random.Random
 
 class GameMapRenderer(private val game: Game) : MapRenderer(true) {
     // TODO GameManagerから読み込む
@@ -16,23 +15,53 @@ class GameMapRenderer(private val game: Game) : MapRenderer(true) {
     private val fieldSize: Pair<Double, Double> = game.field.size.first.toDouble() to game.field.size.second.toDouble()
     private val mapSize: Pair<Int, Int> = Pair(256, 256)
 
-    private val bgImage: BufferedImage
-
-    init {
-        val width = 128
-        val height = 128
-        bgImage = BufferedImage(width, height, BufferedImage.TYPE_INT_RGB)
-        for (x in 0 until width) for (y in 0 until height) bgImage.setRGB(
-            x, y, game.field.getDistrict(
-            x * game.field.size.first / width to y * game.field.size.second / height
-        )?.id?.let {
-            Random(it).nextInt()
-        } ?: 0xFFFFFF
-
-        )
+    private val bgImage: BufferedImage = BufferedImage(128, 128, BufferedImage.TYPE_INT_RGB)
+    private val inBorder: List<List<Boolean>> = List(bgImage.height) { y ->
+        List(bgImage.width) { x ->
+            val district = game.field.getDistrict(
+                x * game.field.size.first / bgImage.width to y * game.field.size.second / bgImage.height
+            )
+            listOf(0 to 1, 1 to 1, 1 to 0, 1 to -1, 0 to -1, -1 to -1, -1 to 0, -1 to 1).any { (dx, dy) ->
+                val neighbor = game.field.getDistrict(
+                    (x + dx) * game.field.size.first / bgImage.width to (y + dy) * game.field.size.second / bgImage.height
+                )
+                neighbor !== null && neighbor != district
+            }
+        }
+    }
+    private val inRoad: List<List<Boolean>> = List(bgImage.height) { y ->
+        List(bgImage.width) cell@{ x ->
+            val (locX, locZ) = x * game.field.size.first / bgImage.width to y * game.field.size.second / bgImage.height
+            val districtIndex = game.field.getDistrict(locX to locZ)?.id ?: return@cell false
+            game.field.graph[districtIndex].ifEmpty { setOf(districtIndex) }.minOf { neighbor ->
+                val coreLoc = game.field.districts[districtIndex].coreLocation
+                val neighborLoc = game.field.districts[neighbor].coreLocation
+                // TODO: 道との距離を正しく計算する
+                //calcDistanceToLineSegment(
+                //    locX.toDouble() to locZ.toDouble(), coreLoc.x to coreLoc.z, neighborLoc.x to neighborLoc.z
+                //)
+                Double.POSITIVE_INFINITY
+            } <= 8
+        }
     }
 
     override fun render(map: MapView, canvas: MapCanvas, player: Player) {
+        for (x in 0 until bgImage.width) for (y in 0 until bgImage.height) {
+            val team = if (inBorder[y][x]) null else game.field.getDistrict(
+                x * game.field.size.first / bgImage.width to y * game.field.size.second / bgImage.height
+            )?.getTeam()
+            bgImage.setRGB(x, y, (team?.color?.getRGB() ?: 0xFFFFFF).let {
+                var r = it shr 16 and 0xFF
+                var g = it shr 8 and 0xFF
+                var b = it and 0xFF
+                if (inRoad[y][x]) {
+                    r = (r * 0.5).toInt()
+                    g = (g * 0.5).toInt()
+                    b = (b * 0.5).toInt()
+                }
+                (r shl 16) or (g shl 8) or b
+            })
+        }
         canvas.drawImage(0, 0, bgImage)
         while (canvas.cursors.size() > 0) canvas.cursors.removeCursor(canvas.cursors.getCursor(0))
 

--- a/src/main/kotlin/jp/trap/conqest/game/Team.kt
+++ b/src/main/kotlin/jp/trap/conqest/game/Team.kt
@@ -1,7 +1,7 @@
 package jp.trap.conqest.game
 
 import org.bukkit.Material
-import java.util.UUID
+import java.util.*
 
 
 class Team(val color: TeamColor) {
@@ -20,15 +20,21 @@ class Team(val color: TeamColor) {
 }
 
 enum class TeamColor {
-    GRAY,
-    RED,
-    BLUE;
+    GRAY, RED, BLUE;
 
     fun getGlassMaterial(): Material {
         return when (this) {
             GRAY -> Material.GRAY_STAINED_GLASS_PANE
             RED -> Material.RED_STAINED_GLASS_PANE
             BLUE -> Material.BLUE_STAINED_GLASS_PANE
+        }
+    }
+
+    fun getRGB(): Int {
+        return when (this) {
+            GRAY -> 0x7D7D73
+            RED -> 0x8E2121
+            BLUE -> 0x2D2F8F
         }
     }
 }

--- a/src/main/kotlin/jp/trap/conqest/game/Team.kt
+++ b/src/main/kotlin/jp/trap/conqest/game/Team.kt
@@ -24,11 +24,11 @@ enum class TeamColor {
     RED,
     BLUE;
 
-    fun getConcreteMaterial(): Material {
+    fun getGlassMaterial(): Material {
         return when (this) {
-            GRAY -> Material.GRAY_CONCRETE
-            RED -> Material.RED_CONCRETE
-            BLUE -> Material.BLUE_CONCRETE
+            GRAY -> Material.GRAY_STAINED_GLASS_PANE
+            RED -> Material.RED_STAINED_GLASS_PANE
+            BLUE -> Material.BLUE_STAINED_GLASS_PANE
         }
     }
 }

--- a/src/main/kotlin/jp/trap/conqest/util/Geometry.kt
+++ b/src/main/kotlin/jp/trap/conqest/util/Geometry.kt
@@ -1,0 +1,19 @@
+package jp.trap.conqest.util
+
+import kotlin.math.abs
+import kotlin.math.hypot
+
+fun calcDistanceToLineSegment(
+    p: Pair<Double, Double>, a: Pair<Double, Double>, b: Pair<Double, Double>
+): Double {
+    val ab = b.first - a.first to b.second - a.second
+    val ap = p.first - a.first to p.second - a.second
+    val bp = p.first - b.first to p.second - b.second
+    if (ab.first * ap.first + ab.second * ap.second <= 0) {
+        return hypot(ap.first, ap.second)
+    }
+    if (-ab.first * bp.first + -ab.second * bp.second <= 0) {
+        return hypot(bp.first, bp.second)
+    }
+    return abs(ab.first * ap.second - ab.second * ap.first) / hypot(ab.first, ab.second)
+}


### PR DESCRIPTION
close #52 

ビーコンの上にガラス板を乗っけて色が変わるようになりました。

マップも同期されます
(そのままだと見にくかったので、境界線を引きました。そしてそのためにいろんな所をちょっといじってます)

![image](https://github.com/user-attachments/assets/ee0cf9b8-31a5-4bf6-b09f-e888f3b8cb2e)

## 以下 AI

このプルリクエストは、ゲームのメカニズムとレンダリングロジックの改善に重点を置いて、`jp.trap.conqest.game`パッケージに対するいくつかの変更を含んでいます。最も重要な変更は、コアブロックの素材をコンクリートからガラスに変更し、`Field`クラスにグラフ構造を追加し、`GameMapRenderer`を強化して地区の境界線と道路をより視覚化しやすくすることです。

### 素材の変更:

* [`src/main/kotlin/jp/trap/conqest/game/District.kt`](diffhunk://#diff-cc97a5417bb9369741ab84f093a155defa5d6147507335af1ddeda1f04056541L18-R25): `coreBlock` を `coreGlass` に置き換え、関連するメソッドを更新してコンクリートではなくガラスの素材を使用するようにしました。 [[1]](diffhunk://#diff-cc97a5417bb9369741ab84f093a155defa5d6147507335af1ddeda1f04056541L18-R25) [[2]](diffhunk://#diff-cc97a5417bb9369741ab84f093a155defa5d6147507335af1ddeda1f04056541L41-R42) [[3]](diffhunk://#diff-cc97a5417bb9369741ab84f093a155defa5d6147507335af1ddeda1f04056541L58-R59)
* [`src/main/kotlin/jp/trap/conqest/game/Team.kt`](diffhunk://#diff-02157145cd2dfdfe8e6b7676174d52f86d0c813623a712a3b214c4bca42518ebL4-R4): `TeamColor` を更新してガラス素材を使用するようにし、色表現のための `getRGB` メソッドを追加しました。 [[1]](diffhunk://#diff-02157145cd2dfdfe8e6b7676174d52f86d0c813623a712a3b214c4bca42518ebL4-R4) [[2]](diffhunk://#diff-02157145cd2dfdfe8e6b7676174d52f86d0c813623a712a3b214c4bca42518ebL23-R37)

### フィールド構造の強化:

* [`src/main/kotlin/jp/trap/conqest/game/Field.kt`](diffhunk://#diff-dd29ff1c8f750ca8952ba6c5cba747eb74c7cde98f07913d88b1d28fd71681edL8-R11): 地区間の接続を表す `graph` プロパティを追加しました。 [[1]](diffhunk://#diff-dd29ff1c8f750ca8952ba6c5cba747eb74c7cde98f07913d88b1d28fd71681edL8-R11) [[2]](diffhunk://#diff-dd29ff1c8f750ca8952ba6c5cba747eb74c7cde98f07913d88b1d28fd71681edR25)
* [`src/main/kotlin/jp/trap/conqest/util/Partition.kt`](diffhunk://#diff-0b871461f187ecc8
