### PR TITLE
Nite の発光色をチームの色にする

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     implementation("org.jetbrains.exposed:exposed-core:0.58.0")
     implementation("org.jetbrains.exposed:exposed-dao:0.58.0")
     implementation("org.jetbrains.exposed:exposed-jdbc:0.58.0")
+    implementation("fr.skytasul:glowingentities:1.4.3")
 }
 
 kotlin {
@@ -57,14 +58,13 @@ tasks.register("createServer") {
 
     doLast {
         File(rootDir, "server/plugins").mkdirs()
-        URI("https://api.papermc.io/v2/projects/paper/versions/1.21.4/builds/118/downloads/paper-1.21.4-118.jar")
-            .toURL().openStream().use { input ->
+        URI("https://api.papermc.io/v2/projects/paper/versions/1.21.4/builds/118/downloads/paper-1.21.4-118.jar").toURL()
+            .openStream().use { input ->
                 File("server/paper.jar").outputStream().use { output ->
                     input.copyTo(output)
                 }
             }
-        File(rootDir, "build/libs/conQest.jar")
-            .copyTo(File(rootDir, "server/plugins/conQest.jar"), overwrite = true)
+        File(rootDir, "build/libs/conQest.jar").copyTo(File(rootDir, "server/plugins/conQest.jar"), overwrite = true)
         File("server/eula.txt").writeText("eula=true")
     }
 }

--- a/src/main/kotlin/jp/trap/conqest/Main.kt
+++ b/src/main/kotlin/jp/trap/conqest/Main.kt
@@ -1,5 +1,6 @@
 package jp.trap.conqest
 
+import fr.skytasul.glowingentities.GlowingEntities
 import jp.trap.conqest.commands.Commands
 import jp.trap.conqest.game.Environment
 import jp.trap.conqest.game.GameManager
@@ -30,6 +31,7 @@ class Main : JavaPlugin() {
     private lateinit var tickTask: BukkitTask
     private lateinit var gameTimerManager: GameTimerManager
     lateinit var gameManager: GameManager
+    lateinit var glowingEntities: GlowingEntities
     private val dbPath = dataPath.resolve("sqlite.db")
 
     companion object {
@@ -83,6 +85,13 @@ class Main : JavaPlugin() {
                     tickTask.cancel()
                     Result.success(Unit)
                 }),
+                FlowTask({
+                    glowingEntities = GlowingEntities(this)
+                    Result.success(Unit)
+                }, {
+                    glowingEntities.disable()
+                    Result.success(Unit)
+                })
             )
         )
     }

--- a/src/main/kotlin/jp/trap/conqest/game/Nite.kt
+++ b/src/main/kotlin/jp/trap/conqest/game/Nite.kt
@@ -3,10 +3,11 @@ package jp.trap.conqest.game
 import net.kyori.adventure.text.Component
 import org.bukkit.Location
 import org.bukkit.attribute.Attribute
-import org.bukkit.entity.*
+import org.bukkit.entity.Entity
+import org.bukkit.entity.EntityType
+import org.bukkit.entity.Mob
+import org.bukkit.entity.Player
 import org.bukkit.plugin.Plugin
-import org.bukkit.potion.PotionEffect
-import org.bukkit.potion.PotionEffectType
 import java.util.*
 
 abstract class Nite<T>(
@@ -28,12 +29,14 @@ abstract class Nite<T>(
 
     init {
         entity.customName(Component.text(name))
-        entity.addPotionEffect(PotionEffect(PotionEffectType.GLOWING, Int.MAX_VALUE, 1))
         if (entity.getAttribute(Attribute.ATTACK_DAMAGE) == null) {
             entity.registerAttribute(Attribute.ATTACK_DAMAGE)
             entity.getAttribute(Attribute.ATTACK_DAMAGE)?.baseValue = damage
         }
-        plugin.server.scheduler.runTaskTimer(plugin, Runnable { state.update() }, 0, 1)
+        plugin.server.scheduler.runTaskTimer(plugin, Runnable {
+            state.update()
+            team.addGlow(entity)
+        }, 0, 1)
     }
 
 

--- a/src/main/kotlin/jp/trap/conqest/game/Nite.kt
+++ b/src/main/kotlin/jp/trap/conqest/game/Nite.kt
@@ -7,8 +7,6 @@ import org.bukkit.damage.DamageSource
 import org.bukkit.damage.DamageType
 import org.bukkit.entity.*
 import org.bukkit.plugin.Plugin
-import org.bukkit.potion.PotionEffect
-import org.bukkit.potion.PotionEffectType
 import org.bukkit.scheduler.BukkitTask
 import java.util.*
 
@@ -38,10 +36,7 @@ abstract class Nite<T>(
             master.sendMessage(damage.toString())
             master.sendMessage("setDamage to ${entity.getAttribute(Attribute.ATTACK_DAMAGE)?.baseValue}")
         }
-        updateTask = plugin.server.scheduler.runTaskTimer(plugin, Runnable {
-            state.update()
-            team.addGlow(entity)
-        }, 0, 1)
+        updateTask = plugin.server.scheduler.runTaskTimer(plugin, Runnable { state.update() }, 0, 1)
     }
 
 

--- a/src/main/kotlin/jp/trap/conqest/game/Team.kt
+++ b/src/main/kotlin/jp/trap/conqest/game/Team.kt
@@ -1,8 +1,11 @@
 package jp.trap.conqest.game
 
+import jp.trap.conqest.Main
+import org.bukkit.Bukkit
+import org.bukkit.ChatColor
 import org.bukkit.Material
+import org.bukkit.entity.Entity
 import java.util.*
-
 
 class Team(val color: TeamColor) {
     companion object {
@@ -10,6 +13,7 @@ class Team(val color: TeamColor) {
     }
 
     private val players = mutableListOf<UUID>()
+
     fun addPlayer(player: UUID) {
         this.players.add(player)
     }
@@ -17,24 +21,32 @@ class Team(val color: TeamColor) {
     fun getPlayers(): List<UUID> {
         return players
     }
+
+    fun addGlow(entity: Entity) {
+        players.forEach {
+            Main.instance.glowingEntities.setGlowing(entity, Bukkit.getPlayer(it), color.getChatColor())
+        }
+    }
 }
 
 enum class TeamColor {
     GRAY, RED, BLUE;
 
-    fun getGlassMaterial(): Material {
-        return when (this) {
-            GRAY -> Material.GRAY_STAINED_GLASS_PANE
-            RED -> Material.RED_STAINED_GLASS_PANE
-            BLUE -> Material.BLUE_STAINED_GLASS_PANE
-        }
+    fun getGlassMaterial(): Material = when (this) {
+        GRAY -> Material.GRAY_STAINED_GLASS_PANE
+        RED -> Material.RED_STAINED_GLASS_PANE
+        BLUE -> Material.BLUE_STAINED_GLASS_PANE
     }
 
-    fun getRGB(): Int {
-        return when (this) {
-            GRAY -> 0x7D7D73
-            RED -> 0x8E2121
-            BLUE -> 0x2D2F8F
-        }
+    fun getRGB(): Int = when (this) {
+        GRAY -> 0x7D7D73
+        RED -> 0x8E2121
+        BLUE -> 0x2D2F8F
+    }
+
+    fun getChatColor(): ChatColor = when (this) {
+        GRAY -> ChatColor.GRAY
+        RED -> ChatColor.RED
+        BLUE -> ChatColor.BLUE
     }
 }

--- a/src/main/kotlin/jp/trap/conqest/game/Team.kt
+++ b/src/main/kotlin/jp/trap/conqest/game/Team.kt
@@ -5,6 +5,7 @@ import org.bukkit.Bukkit
 import org.bukkit.ChatColor
 import org.bukkit.Material
 import org.bukkit.entity.Entity
+import org.bukkit.entity.Player
 import java.util.*
 
 class Team(val color: TeamColor) {
@@ -22,9 +23,9 @@ class Team(val color: TeamColor) {
         return players
     }
 
-    fun addGlow(entity: Entity) {
-        players.forEach {
-            Main.instance.glowingEntities.setGlowing(entity, Bukkit.getPlayer(it), color.getChatColor())
+    fun glow(entity: Entity, targets: List<Player>) {
+        targets.forEach {
+            Main.instance.glowingEntities.setGlowing(entity, it, color.getChatColor())
         }
     }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -6,3 +6,4 @@ author: ${author}
 api-version: ${apiVersion}
 libraries:
   - org.jetbrains.kotlin:kotlin-stdlib:${kotlinVersion}
+  - fr.skytasul:glowingentities:1.4.3


### PR DESCRIPTION
close #97

自分でチーム作ってやっても色が消えたりすることがあったので、ライブラリを入れてやってます (たぶんパケット操作してます

## 以下 AI の説明

This pull request introduces the integration of the `GlowingEntities` library to enhance the visual effects in the game. The most important changes include importing the library, initializing it, and adding methods to manage entity glow effects.

Integration of `GlowingEntities` library:

* [`src/main/kotlin/jp/trap/conqest/Main.kt`](diffhunk://#diff-0776ddd3763dc147035ee6520d702e6e1eb0bc3e81b5352c8464a1c3f68fda54R3): Imported `GlowingEntities`, added a `glowingEntities` property, and initialized it within the `FlowTask`. [[1]](diffhunk://#diff-0776ddd3763dc147035ee6520d702e6e1eb0bc3e81b5352c8464a1c3f68fda54R3) [[2]](diffhunk://#diff-0776ddd3763dc147035ee6520d702e6e1eb0bc3e81b5352c8464a1c3f68fda54R34) [[3]](diffhunk://#diff-0776ddd3763dc147035ee6520d702e6e1eb0bc3e81b5352c8464a1c3f68fda54R88-R94)
* [`src/main/resources/plugin.yml`](diffhunk://#diff-98201effe40eaf4a0e8826fadd6c5c9d5beaf9d737226b514f0853f44987a67fR9): Added `GlowingEntities` as a library dependency.

Enhancements to entity glow effects:

* [`src/main/kotlin/jp/trap/conqest/game/Nite.kt`](diffhunk://#diff-5eb2a924c58ea68fa77624864bd57a2308be177e297c08f5971646d81d3ec0c0L31-R39): Removed direct potion effect for glowing and replaced it with a call to `team.addGlow(entity)` within the task scheduler.
* [`src/main/kotlin/jp/trap/conqest/game/Team.kt`](diffhunk://#diff-02157145cd2dfdfe8e6b7676174d52f86d0c813623a712a3b214c4bca42518ebR3-R50): Added methods to handle glowing effects for entities and linked it with the `GlowingEntities` library.)
